### PR TITLE
feat: add deadline option to meta aggregator

### DIFF
--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -108,7 +108,7 @@ export type QuoteSelectionStrategy = QuoteSelectionName | QuoteSelectionFn;
 export type MetaAggregationOptions = AggregationOptions & {
   /// The strategy to use for selecting the best quote (only applies to methods returning a single quote)
   strategy?: QuoteSelectionStrategy;
-  /// The maximum time to wait for the entire aggregation process
+  /// The maximum time to wait for the entire aggregation process (pending requests are aborted once this deadline is hit)
   deadlineMs?: number;
 };
 

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -12,7 +12,10 @@ export const defaultSwapParams: SwapParams = {
 
 export class MockAggregator extends Aggregator {
   private counter = 0;
-  constructor(private readonly quote: Quote) {
+  constructor(
+    private readonly quote: Quote,
+    private delay?: number,
+  ) {
     super();
   }
 
@@ -26,6 +29,10 @@ export class MockAggregator extends Aggregator {
 
   async tryFetchQuote(_: SwapParams): Promise<SuccessfulQuote> {
     this.counter++;
+    if (this.delay) {
+      await new Promise((resolve) => setTimeout(resolve, this.delay));
+    }
+
     if (!this.quote.success) {
       throw new Error("Failed to fetch quote");
     }


### PR DESCRIPTION
Caps the amount of time any provider can take to keep quotes for well behaving providers fresh.