### PR TITLE
api: update provider configuration API

### DIFF
--- a/examples/react/src/routes/__root.tsx
+++ b/examples/react/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import {
   HeadContent,
   Scripts,
 } from "@tanstack/react-router";
+import { kyberswap, odos } from "@withfabric/spandex";
 import { SpandexProvider } from "@withfabric/spandex-react";
 import { Tooltip } from "radix-ui";
 import { DialogPortal } from "@/components/Dialog";
@@ -73,10 +74,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <Web3Provider>
             <SpandexProvider
               config={{
-                providers: {
-                  odos: {},
-                  kyberswap: { clientId: "spandex_ui" },
-                },
+                providers: [odos({}), kyberswap({ clientId: "spandex_ui" })],
               }}
             >
               <Tooltip.Provider>

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,9 +1,9 @@
-import { ZeroXAggregator } from "./lib/aggregators/0x.js";
-import { FabricAggregator } from "./lib/aggregators/fabric.js";
-import { KyberAggregator } from "./lib/aggregators/kyber.js";
-import { LifiAggregator } from "./lib/aggregators/lifi.js";
-import { OdosAggregator } from "./lib/aggregators/odos.js";
-import { RelayAggregator } from "./lib/aggregators/relay.js";
+import { ZeroXAggregator, zeroX } from "./lib/aggregators/0x.js";
+import { FabricAggregator, fabric } from "./lib/aggregators/fabric.js";
+import { KyberAggregator, kyberswap } from "./lib/aggregators/kyber.js";
+import { LifiAggregator, lifi } from "./lib/aggregators/lifi.js";
+import { OdosAggregator, odos } from "./lib/aggregators/odos.js";
+import { RelayAggregator, relay } from "./lib/aggregators/relay.js";
 
 export {
   FabricAggregator,
@@ -12,6 +12,12 @@ export {
   LifiAggregator,
   OdosAggregator,
   RelayAggregator,
+  fabric,
+  zeroX,
+  kyberswap,
+  lifi,
+  odos,
+  relay,
 };
 export { Aggregator } from "./lib/aggregators/index.js";
 export { type Config, createConfig, defaultProviders } from "./lib/createConfig.js";

--- a/packages/core/lib/aggregators/0x.ts
+++ b/packages/core/lib/aggregators/0x.ts
@@ -116,6 +116,10 @@ export class ZeroXAggregator extends Aggregator<ZeroXConfig> {
   }
 }
 
+export function zeroX(config: ZeroXConfig): ZeroXAggregator {
+  return new ZeroXAggregator(config);
+}
+
 function extractQueryParams(
   params: ExactInSwapParams,
   options: SwapOptions,

--- a/packages/core/lib/aggregators/fabric.ts
+++ b/packages/core/lib/aggregators/fabric.ts
@@ -180,6 +180,10 @@ export class FabricAggregator extends Aggregator<FabricConfig> {
   }
 }
 
+export function fabric(config: FabricConfig): FabricAggregator {
+  return new FabricAggregator(config);
+}
+
 export function fabricRouteGraph(quote: FabricQuoteResponse): RouteGraph {
   const swaps = quote.route.swaps.flat();
   const nodes = quote.tokens;

--- a/packages/core/lib/aggregators/kyber.ts
+++ b/packages/core/lib/aggregators/kyber.ts
@@ -149,6 +149,10 @@ export class KyberAggregator extends Aggregator<KyberConfig> {
   }
 }
 
+export function kyberswap(config?: KyberConfig): KyberAggregator {
+  return new KyberAggregator(config);
+}
+
 function extractQueryParams(
   params: ExactInSwapParams,
   options: SwapOptions,

--- a/packages/core/lib/aggregators/lifi.ts
+++ b/packages/core/lib/aggregators/lifi.ts
@@ -148,6 +148,10 @@ export class LifiAggregator extends Aggregator<LifiConfig> {
   }
 }
 
+export function lifi(config?: LifiConfig): LifiAggregator {
+  return new LifiAggregator(config);
+}
+
 function buildQueryParams(params: ExactInSwapParams, options: SwapOptions): Record<string, string> {
   const result: Record<string, string> = {
     fromChain: params.chainId.toString(),

--- a/packages/core/lib/aggregators/odos.ts
+++ b/packages/core/lib/aggregators/odos.ts
@@ -187,6 +187,10 @@ export class OdosAggregator extends Aggregator<OdosConfig> {
   }
 }
 
+export function odos(config?: OdosConfig): OdosAggregator {
+  return new OdosAggregator(config);
+}
+
 /**
  * Request payload accepted by the Odos `/sor/quote/v3` endpoint.
  *

--- a/packages/core/lib/aggregators/relay.ts
+++ b/packages/core/lib/aggregators/relay.ts
@@ -109,6 +109,10 @@ export class RelayAggregator extends Aggregator<RelayConfig> {
   }
 }
 
+export function relay(config?: RelayConfig): RelayAggregator {
+  return new RelayAggregator(config);
+}
+
 function buildRequest(request: SwapParams, options: SwapOptions): RelayQuoteRequest {
   const tradeType = request.mode === "exactIn" ? "EXACT_INPUT" : "EXPECTED_OUTPUT";
   const amount = request.mode === "exactIn" ? request.inputAmount : request.outputAmount;

--- a/packages/core/lib/createConfig.test.ts
+++ b/packages/core/lib/createConfig.test.ts
@@ -1,22 +1,19 @@
 import { describe, expect, it } from "bun:test";
+import { zeroX } from "./aggregators/0x.js";
 import { createConfig } from "./createConfig.js";
 
 describe("createConfig", () => {
   it("throws on misconfiguration", async () => {
     expect(() => {
       createConfig({
-        providers: {},
+        providers: [],
       });
     }).toThrow();
   });
 
   it("supports manual configuration", async () => {
     const config = createConfig({
-      providers: {
-        "0x": {
-          apiKey: "test",
-        },
-      },
+      providers: [zeroX({ apiKey: "test" })],
     });
 
     expect(config).toBeDefined();

--- a/packages/core/lib/createConfig.ts
+++ b/packages/core/lib/createConfig.ts
@@ -1,11 +1,8 @@
 import type { PublicClient } from "viem";
-import { ZeroXAggregator } from "./aggregators/0x.js";
-import { FabricAggregator } from "./aggregators/fabric.js";
+import { fabric } from "./aggregators/fabric.js";
 import type { Aggregator } from "./aggregators/index.js";
-import { KyberAggregator } from "./aggregators/kyber.js";
-import { LifiAggregator } from "./aggregators/lifi.js";
-import { OdosAggregator } from "./aggregators/odos.js";
-import { RelayAggregator } from "./aggregators/relay.js";
+import { kyberswap } from "./aggregators/kyber.js";
+import { odos } from "./aggregators/odos.js";
 import type { AggregationOptions, ConfigParams } from "./types.js";
 
 /**
@@ -25,14 +22,10 @@ export type Config = {
  *
  * @param params.appId - Id used to identify your application to providers that require it.
  *
- * @returns Provider configuration object with default providers enabled.
+ * @returns Provider list with default aggregators enabled.
  */
 export function defaultProviders(params: { appId: string }): ConfigParams["providers"] {
-  return {
-    kyberswap: { clientId: params.appId },
-    fabric: { appId: params.appId },
-    odos: {},
-  };
+  return [kyberswap({ clientId: params.appId }), fabric({ appId: params.appId }), odos({})];
 }
 
 /**
@@ -45,10 +38,10 @@ export function defaultProviders(params: { appId: string }): ConfigParams["provi
  * @example
  * ```ts
  * const config = createConfig({
- *   providers: {
- *     "0x": { apiKey: "your-0x-api-key" },
- *     kyberswap: { clientId: "your-kyberswap-client-id" },
- *   },
+ *   providers: [
+ *     zeroX({ apiKey: "your-0x-api-key" }),
+ *     kyberswap({ clientId: "your-kyberswap-client-id" }),
+ *   ],
  *   options: {
  *     deadlineMs: 10000,
  *   },
@@ -56,33 +49,12 @@ export function defaultProviders(params: { appId: string }): ConfigParams["provi
  * ```
  */
 export function createConfig(params: ConfigParams): Config {
-  if (Object.keys(params.providers).length === 0) {
+  if (params.providers.length === 0) {
     throw new Error(
       "At least one provider must be configured in createConfig. You can also use defaultProviders({ appId: 'my-app-id' }) to get a standard set of providers.",
     );
   }
-
-  const aggregators = [];
-
-  const configured = params.providers;
-  if (configured["0x"]) {
-    aggregators.push(new ZeroXAggregator(configured["0x"]));
-  }
-  if (configured.kyberswap) {
-    aggregators.push(new KyberAggregator(configured.kyberswap));
-  }
-  if (configured.fabric) {
-    aggregators.push(new FabricAggregator(configured.fabric));
-  }
-  if (configured.lifi) {
-    aggregators.push(new LifiAggregator(configured.lifi));
-  }
-  if (configured.odos) {
-    aggregators.push(new OdosAggregator(configured.odos));
-  }
-  if (configured.relay) {
-    aggregators.push(new RelayAggregator(configured.relay));
-  }
+  const aggregators = params.providers;
 
   validateOptions(params.options || {});
 

--- a/packages/core/lib/executeQuote.test.ts
+++ b/packages/core/lib/executeQuote.test.ts
@@ -5,6 +5,7 @@ import { createPublicClient, createWalletClient, erc20Abi, http, type PublicClie
 import { base } from "viem/chains";
 import { recordedSimulation } from "../test/utils.js";
 import type { FabricQuoteResponse } from "./aggregators/fabric.js";
+import { fabric } from "./aggregators/fabric.js";
 import { createConfig } from "./createConfig.js";
 import { executeQuote } from "./executeQuote.js";
 import type { SwapParams } from "./types.js";
@@ -63,9 +64,7 @@ describe("executeQuote", () => {
 
   it("can execute a quote on a forked chain", async () => {
     const config = createConfig({
-      providers: {
-        fabric: { appId: "test" },
-      },
+      providers: [fabric({ appId: "test" })],
       clients: [baseClient] as PublicClient[],
     });
 

--- a/packages/core/lib/getQuotes.test.ts
+++ b/packages/core/lib/getQuotes.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from "bun:test";
 import type { PublicClient } from "viem";
 import { createPublicClient, http, zeroAddress } from "viem";
 import { base } from "viem/chains";
-import { getQuotes, type SuccessfulQuote, type SwapParams } from "../index.js";
+import {
+  fabric,
+  getQuotes,
+  kyberswap,
+  odos,
+  type SuccessfulQuote,
+  type SwapParams,
+  zeroX,
+} from "../index.js";
 import { createConfig } from "./createConfig.js";
 
 const defaultSwapParams: SwapParams = {
@@ -26,12 +34,12 @@ describe("getQuotes", () => {
   }) as PublicClient;
 
   const config = createConfig({
-    providers: {
-      odos: {},
-      kyberswap: { clientId: "spandex" },
-      fabric: { appId: "spandex" },
-      "0x": { apiKey: process.env.ZEROX_API_KEY || "" },
-    },
+    providers: [
+      odos({}),
+      kyberswap({ clientId: "spandex" }),
+      fabric({ appId: "spandex" }),
+      zeroX({ apiKey: process.env.ZEROX_API_KEY || "" }),
+    ],
     clients: [client] as PublicClient[],
   });
 

--- a/packages/core/lib/prepareQuotes.test.ts
+++ b/packages/core/lib/prepareQuotes.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { zeroX } from "./aggregators/0x.js";
+import { fabric } from "./aggregators/fabric.js";
 import { type Config, createConfig } from "./createConfig.js";
 import { prepareQuotes } from "./prepareQuotes.js";
 import type { Quote } from "./types.js";
@@ -6,10 +8,7 @@ import type { Quote } from "./types.js";
 describe("prepareQuotes", () => {
   it("prepares an array of promises", async () => {
     const config: Config = createConfig({
-      providers: {
-        "0x": { apiKey: "test" },
-        fabric: { appId: "test" },
-      },
+      providers: [zeroX({ apiKey: "test" }), fabric({ appId: "test" })],
     });
 
     const prepared = prepareQuotes({

--- a/packages/core/lib/simulateQuote.test.ts
+++ b/packages/core/lib/simulateQuote.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Address, PublicClient } from "viem";
 import { createPublicClient, http } from "viem";
 import { base } from "viem/chains";
-import { createConfig, getRawQuotes, type SwapParams } from "../index.js";
+import { createConfig, fabric, getRawQuotes, kyberswap, type SwapParams } from "../index.js";
 import { simulateQuotes } from "./simulateQuote.js";
 import type { SimulatedQuote } from "./types.js";
 
@@ -26,10 +26,7 @@ describe("simulateQuote", () => {
   }) as PublicClient;
 
   const config = createConfig({
-    providers: {
-      kyberswap: { clientId: "spandex-test-env" },
-      fabric: { appId: "spandex-test-env" },
-    },
+    providers: [kyberswap({ clientId: "spandex-test-env" }), fabric({ appId: "spandex-test-env" })],
     clients: [client] as PublicClient[],
   });
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -1,6 +1,7 @@
 import type { Address, PublicClient, SimulateCallsReturnType } from "viem";
 import type { ZeroXConfig, ZeroXQuoteResponse } from "./aggregators/0x.js";
 import type { FabricConfig, FabricQuoteResponse } from "./aggregators/fabric.js";
+import type { Aggregator } from "./aggregators/index.js";
 import type { KyberConfig, KyberQuoteResponse } from "./aggregators/kyber.js";
 import type { LifiConfig, LifiQuoteResponse } from "./aggregators/lifi.js";
 import type { OdosConfig, OdosQuoteResponse } from "./aggregators/odos.js";
@@ -55,13 +56,6 @@ export type ProviderConfig = {
    */
   negotiatedFeatures?: NegotiatedFeature[];
 };
-
-/**
- * Provider-specific configuration keyed by the provider identifier.
- *
- * Supply only the providers you want enabled; omitted keys are skipped entirely.
- */
-export type ProvidersConfig = Partial<{ [K in ProviderKey]: ProviderDefinitions[K]["config"] }>;
 
 /**
  * Features that an aggregator may support. Used for capability detection and filtering.
@@ -435,9 +429,9 @@ export type AggregationOptions = TimingOptions & FeeOptions;
  */
 export type ConfigParams = {
   /**
-   * Provider-specific configuration keyed by provider identifier (optional to allow a subset).
+   * Aggregator instances to include in the meta-aggregator.
    */
-  providers: ProvidersConfig;
+  providers: Aggregator[];
   /**
    * Clients used to simulate quotes (one per chain).
    */

--- a/packages/core/lib/util/netOutputs.test.ts
+++ b/packages/core/lib/util/netOutputs.test.ts
@@ -6,6 +6,9 @@ import {
   USDC_WHALE,
 } from "packages/core/test/utils.js";
 import type { Address } from "viem";
+import { zeroX } from "../aggregators/0x.js";
+import { fabric } from "../aggregators/fabric.js";
+import { kyberswap } from "../aggregators/kyber.js";
 import type { SwapParams } from "../types.js";
 import { netOutputs } from "./netOutputs.js";
 
@@ -20,9 +23,7 @@ describe("netOutputs", () => {
     const quote = await recordedSimulation(
       "netOutputs-erc20-out",
       swap,
-      testConfig({
-        fabric: { appId: "spandex" },
-      }),
+      testConfig([fabric({ appId: "spandex" })]),
     );
 
     const net = netOutputs({
@@ -48,9 +49,7 @@ describe("netOutputs", () => {
     const quote = await recordedSimulation(
       "netout-kyberswap-erc20-out",
       swap,
-      testConfig({
-        kyberswap: { clientId: "test-setup" },
-      }),
+      testConfig([kyberswap({ clientId: "test-setup" })]),
     );
 
     const net = netOutputs({
@@ -76,11 +75,7 @@ describe("netOutputs", () => {
     const quote = await recordedSimulation(
       "netout-0x-erc20-out",
       swap,
-      testConfig({
-        "0x": {
-          apiKey: process.env.ZEROX_API_KEY || "demo",
-        },
-      }),
+      testConfig([zeroX({ apiKey: process.env.ZEROX_API_KEY || "demo" })]),
     );
 
     const net = netOutputs({

--- a/packages/core/lib/wire/streams.test.ts
+++ b/packages/core/lib/wire/streams.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { defaultSwapParams, testConfig } from "packages/core/test/utils.js";
+import { fabric } from "../aggregators/fabric.js";
+import { kyberswap } from "../aggregators/kyber.js";
 import { prepareQuotes } from "../prepareQuotes.js";
 import { decodeQuoteStream, newQuoteStream } from "./streams.js";
 
@@ -7,14 +9,10 @@ describe("streaming", () => {
   it("properly streams serialized quotes", async () => {
     const quotes = prepareQuotes({
       swap: defaultSwapParams,
-      config: testConfig({
-        fabric: {
-          appId: "test-fabric-key",
-        },
-        kyberswap: {
-          clientId: "test-kyberswap-key",
-        },
-      }),
+      config: testConfig([
+        fabric({ appId: "test-fabric-key" }),
+        kyberswap({ clientId: "test-kyberswap-key" }),
+      ]),
       mapFn: async (quote) => {
         return quote;
       },

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -7,7 +7,6 @@ import type {
   AggregatorFeature,
   AggregatorMetadata,
   ProviderKey,
-  ProvidersConfig,
   Quote,
   SuccessfulQuote,
   SuccessfulSimulatedQuote,
@@ -91,7 +90,7 @@ export class MockAggregator extends Aggregator {
   }
 }
 
-export function testConfig(providers: ProvidersConfig) {
+export function testConfig(providers: Aggregator[]) {
   return createConfig({
     providers,
     clients: [

--- a/packages/react/lib/context/SpandexProvider.test.tsx
+++ b/packages/react/lib/context/SpandexProvider.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { fabric, zeroX } from "@withfabric/spandex";
 import { render, screen } from "../../test/utils.js";
 import { useSpandexConfig } from "./SpandexProvider.js";
 
@@ -18,10 +19,7 @@ describe("SpandexProvider", () => {
   it("should provide metaAggregator to children", () => {
     render(<TestComponent />, {
       spandexConfig: {
-        providers: {
-          "0x": { apiKey: "test" },
-          fabric: {},
-        },
+        providers: [zeroX({ apiKey: "test" }), fabric({ appId: "test" })],
       },
     });
 

--- a/packages/react/test/utils.tsx
+++ b/packages/react/test/utils.tsx
@@ -5,6 +5,7 @@ import {
   render as tlRender,
   renderHook as tlRenderHook,
 } from "@testing-library/react";
+import { fabric } from "@withfabric/spandex";
 import type { ReactNode } from "react";
 import { createConfig, http, WagmiProvider } from "wagmi";
 import { base, mainnet } from "wagmi/chains";
@@ -21,7 +22,7 @@ const wagmiConfig = createConfig({
 });
 
 export const DEFAULT_TEST_CONFIG: SpandexProviderProps["config"] = {
-  providers: { fabric: {} },
+  providers: [fabric({ appId: "test" })],
 };
 
 export function createWrapper(config?: SpandexProviderProps["config"]) {

--- a/site/docs/pages/core/functions/createConfig.mdx
+++ b/site/docs/pages/core/functions/createConfig.mdx
@@ -2,20 +2,18 @@ import ConfigParams from '../../../snippets/params/config.mdx'
 
 # createConfig
 
-Create a configuration object to customize proivders and options for all aggregation functions.
+Create a configuration object to customize providers and options for all aggregation functions.
 
 ```ts
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, fabric, kyberswap, odos, zeroX } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    '0x': {
-      apiKey: "YOUR_0X_API_KEY",
-    },
-    fabric: { appId: "YOUR_FABRIC_APP_ID" },
-    odos: {},
-    kyberswap: { clientId: "YOUR_KYBER_CLIENT_ID" },
-  },
+  providers: [
+    zeroX({ apiKey: "YOUR_0X_API_KEY" }),
+    fabric({ appId: "YOUR_FABRIC_APP_ID" }),
+    odos({}),
+    kyberswap({ clientId: "YOUR_KYBER_CLIENT_ID" }),
+  ],
   options: {
     deadlineMs: 10000,
     numRetries: 2,

--- a/site/docs/pages/core/functions/getQuotes.mdx
+++ b/site/docs/pages/core/functions/getQuotes.mdx
@@ -36,9 +36,7 @@ for (const quote of quotes) {
 ```
 
 ```ts [config] filename="config.ts" twoslash
-import {
-  createConfig
-} from "@withfabric/spandex";
+import { createConfig, fabric, odos } from "@withfabric/spandex";
 import { createPublicClient, http, type PublicClient } from "viem";
 import { base } from "viem/chains";
 
@@ -48,11 +46,7 @@ const client = createPublicClient({
 });
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "your app id" },
-    odos: {},
-  }
-  ,
+  providers: [fabric({ appId: "your app id" }), odos({})],
   clients: [client] as PublicClient[],
 });
 ```

--- a/site/docs/pages/core/functions/getRawQuotes.mdx
+++ b/site/docs/pages/core/functions/getRawQuotes.mdx
@@ -25,15 +25,10 @@ const quotes = await getRawQuotes({
 ```
 
 ```ts [config] filename="config.ts" twoslash
-import {
-  createConfig
-} from "@withfabric/spandex";
+import { createConfig, fabric, odos } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "your app id" },
-    odos: {},
-  }
+  providers: [fabric({ appId: "your app id" }), odos({})],
 });
 ```
 

--- a/site/docs/pages/core/functions/prepareQuotes.mdx
+++ b/site/docs/pages/core/functions/prepareQuotes.mdx
@@ -31,7 +31,7 @@ const promises = prepareQuotes({
 ```
 
 ```ts [config.ts] filename="config.ts" twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, fabric, odos } from "@withfabric/spandex";
 import { createPublicClient, http, type PublicClient } from "viem";
 import { base } from "viem/chains";
 
@@ -41,10 +41,7 @@ const client = createPublicClient({
 });
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "your app id" },
-    odos: {},
-  },
+  providers: [fabric({ appId: "your app id" }), odos({})],
   clients: [client] as PublicClient[],
 });
 ```

--- a/site/docs/pages/core/getting-started.mdx
+++ b/site/docs/pages/core/getting-started.mdx
@@ -25,7 +25,7 @@ bun i viem @withfabic/spandex
 See the [configuration reference](/configuration.mdx) for all options.
 
 ```ts filename="config.ts" twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, fabric, kyberswap, odos } from "@withfabric/spandex";
 import { createPublicClient, http, type PublicClient } from "viem";
 import { base } from "viem/chains";
 
@@ -37,11 +37,7 @@ const baseClient = createPublicClient({
 
 // The aggregator instance can be shared across your application
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "test" },
-    odos: {},
-    kyberswap: { clientId: "test" },
-  },
+  providers: [fabric({ appId: "test" }), odos({}), kyberswap({ clientId: "test" })],
   clients: [baseClient] as PublicClient[],
 });
 ```

--- a/site/docs/pages/providers/0x.mdx
+++ b/site/docs/pages/providers/0x.mdx
@@ -14,18 +14,20 @@ import { Callout } from 'vocs/components'
   0x requires an API key for access. You can obtain one by [signing up](https://dashboard.0x.org/create-account).
 </Callout>
 
+Use the `zeroX` factory since JavaScript identifiers cannot start with a number.
+
 ```ts twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, zeroX } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    '0x': {
+  providers: [
+    zeroX({
       // required!
       apiKey: "YOUR_0X_API_KEY",
       // If you have negotiated surplus sharing with 0x, override negotiatedOptions
       // negotiatedFeatures: ["integratorSurplus"],
-    },
+    }),
     // ...
-  },
+  ],
 });
 ```

--- a/site/docs/pages/providers/fabric.mdx
+++ b/site/docs/pages/providers/fabric.mdx
@@ -11,18 +11,18 @@ import { Callout } from 'vocs/components'
 ## Configuration
 
 ```ts twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, fabric } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    fabric: {
+  providers: [
+    fabric({
       appId: "YOUR_FABRIC_APP_ID",
       // Optional, use if you have negotiated service
       apiKey: "YOUR_FABRIC_API_KEY",
       // Optional, only set if you have a private Fabric deployment
       url: undefined,
-    },
+    }),
     // ...
-  },
+  ],
 });
 ```

--- a/site/docs/pages/providers/kyberswap.mdx
+++ b/site/docs/pages/providers/kyberswap.mdx
@@ -11,15 +11,15 @@ import { Callout } from 'vocs/components'
 ## Configuration
 
 ```ts twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, kyberswap } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    kyberswap: {
+  providers: [
+    kyberswap({
       // Required, you choose the value
       clientId: "myawesomeapp",
-    },
+    }),
     // ...
-  },
+  ],
 });
 ```

--- a/site/docs/pages/providers/odos.mdx
+++ b/site/docs/pages/providers/odos.mdx
@@ -11,20 +11,19 @@ import { Callout } from 'vocs/components'
 ## Configuration
 
 ```ts twoslash
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, odos } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    odos: {
+  providers: [
+    odos({
       // Optional. Use for attribution
       referralCode: undefined,
       // Optional. Use it if you got it
       apiKey: undefined,
       // Optional. Enable fees and surplus if negotiated with Odos.
       // negotiatedFeatures: ["integratorSurplus", "integratorFees"],
-    },
+    }),
     // ...
-  },
+  ],
 });
 ```
-

--- a/site/docs/pages/react/getting-started.mdx
+++ b/site/docs/pages/react/getting-started.mdx
@@ -28,12 +28,10 @@ See the [configuration reference](/configuration.mdx) for all options.
 import { WagmiProvider } from "wagmi";
 import { wagmiConfig } from "./wagmiConfig.js";
 import { SpandexProvider } from "@withfabric/spandex-react";
+import { fabric, zeroX } from "@withfabric/spandex";
 
 const config = {
-  aggregators: [
-    { provider: "fabric", config: {} },
-    { provider: "0x", config: {} },
-  ],
+  providers: [fabric({ appId: "YOUR_FABRIC_APP_ID" }), zeroX({ apiKey: "YOUR_0X_API_KEY" })],
 };
 
 export function App() {
@@ -77,4 +75,3 @@ export function Quotes() {
   );
 }
 ```
-

--- a/site/docs/snippets/config.ts
+++ b/site/docs/snippets/config.ts
@@ -1,4 +1,4 @@
-import { createConfig } from "@withfabric/spandex";
+import { createConfig, fabric, kyberswap, odos } from "@withfabric/spandex";
 import { createPublicClient, http, type PublicClient } from "viem";
 import { base } from "viem/chains";
 
@@ -9,11 +9,11 @@ const baseClient = createPublicClient({
 });
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "your app id" },
-    odos: { referralCode: 1234 },
-    kyberswap: { clientId: "your client id" },
-  },
+  providers: [
+    fabric({ appId: "your app id" }),
+    odos({ referralCode: 1234 }),
+    kyberswap({ clientId: "your client id" }),
+  ],
   options: {
     deadlineMs: 5_000,
     integratorFeeAddress: "0xFee00000000000000000000000000000000000fee",

--- a/site/docs/snippets/example.ts
+++ b/site/docs/snippets/example.ts
@@ -1,15 +1,11 @@
-import { createConfig, getQuote } from "@withfabric/spandex";
+import { createConfig, fabric, getQuote, kyberswap, odos } from "@withfabric/spandex";
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "spandex" },
-    kyberswap: {
-      clientId: "spandex",
-    },
-    odos: {
-      referralCode: 1234,
-    },
-  },
+  providers: [
+    fabric({ appId: "spandex" }),
+    kyberswap({ clientId: "spandex" }),
+    odos({ referralCode: 1234 }),
+  ],
   options: {
     deadlineMs: 10_000,
     integratorFeeAddress: "0xFee00000000000000000000000000000000000fee",

--- a/site/docs/snippets/executing-quotes.ts
+++ b/site/docs/snippets/executing-quotes.ts
@@ -1,5 +1,5 @@
 import type { ExactInSwapParams } from "@withfabric/spandex";
-import { createConfig, getQuote } from "@withfabric/spandex";
+import { createConfig, fabric, getQuote } from "@withfabric/spandex";
 import { createWalletClient, http } from "viem";
 import { base } from "viem/chains";
 
@@ -10,9 +10,7 @@ const walletClient = createWalletClient({
 });
 
 export const config = createConfig({
-  providers: {
-    fabric: { appId: "your app id" },
-  },
+  providers: [fabric({ appId: "your app id" })],
 });
 
 const swap: ExactInSwapParams = {

--- a/site/docs/snippets/params/config.mdx
+++ b/site/docs/snippets/params/config.mdx
@@ -2,32 +2,35 @@
 
 ### providers
 
-`Partial<{ [K in ProviderKey]: ProviderDefinitions[K]["config"] }>`
+`Aggregator[]`
 
-The map of active providers and their configuration. Each provider has its own configuration options.
+List of active provider aggregators. Each provider has a factory function that returns an
+`Aggregator` instance with its configuration. You can include multiple instances for the same
+provider to test alternate configurations.
 
-| Key | API Key Required? | Config Docs |
+| Factory | API Key Required? | Config Docs |
 |----------|-----------|----------|
-| `0x` | yes | [View](/providers/0x.mdx) |
+| `zeroX` | yes | [View](/providers/0x.mdx) |
 | `fabric` | no | [View](/providers/fabric.mdx) |
 | `kyberswap` | no | [View](/providers/kyberswap.mdx) |
-| `1inch` | no | [View](/providers/1inch.mdx) |
 | `odos` | no | [View](/providers/odos.mdx) |
 | `lifi` | no | [View](/providers/lifi.mdx) |
 
 Example:
 
 ```ts
-const providerConfig: ProvidersConfig = {
-  '0x': {
+import { fabric, zeroX } from "@withfabric/spandex";
+
+const providers = [
+  zeroX({
     apiKey: "YOUR_0X_API_KEY",
     timeoutMs: 12_000,
     negotiatedFeatures: ["integratorFees"],
-  },
-  fabric: {
+  }),
+  fabric({
     appId: "YOUR_FABRIC_APP_ID",
-  },
-};
+  }),
+];
 ```
 
 ---


### PR DESCRIPTION
Rather than scope to a pre-defined mapping of providers, allow any Aggregator instance while having a similar feeling API.

