### PR TITLE
fix: update rendering of bump chart to recognize missing data

### DIFF
--- a/examples/react/src/routes/api/quotes.ts
+++ b/examples/react/src/routes/api/quotes.ts
@@ -18,11 +18,10 @@ const config = createConfig({
     odos({}),
     kyberswap({ clientId: "spandex_ui" }),
     fabric({ appId: "spandex_ui" }),
-    zeroX({ apiKey: process.env.ZEROX_API_KEY || "" }),
-  ],
+    process.env.ZEROX_API_KEY ? zeroX({ apiKey: process.env.ZEROX_API_KEY }) : undefined,
+  ].filter((p): p is NonNullable<typeof p> => Boolean(p)),
   options: {
     deadlineMs: 5_000,
-    // Add integrator fees, etc
   },
 });
 


### PR DESCRIPTION
Include all providers in all rounds, using null for the rank value in the event the provider fails to provide a quote, or the quote reverts during simulation.