### PR TITLE
fix(relay): send correct slippage tolerance value

### DIFF
--- a/.changeset/funky-ghosts-beg.md
+++ b/.changeset/funky-ghosts-beg.md
@@ -1,0 +1,6 @@
+---
+"@spandex/core": patch
+"@spandex/react": patch
+---
+
+Fix slippage calculation for relay. If a user requested 1% slippage cap, the value sent to relay represented 1 basis point.

--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.4",
-        "@types/bun": "^1.3.10",
-        "@types/node": "^25.4.0",
+        "@types/bun": "^1.3.11",
+        "@types/node": "^25.5.0",
         "typescript": "^5.9.3",
       },
     },

--- a/packages/core/lib/aggregators/relay.ts
+++ b/packages/core/lib/aggregators/relay.ts
@@ -169,9 +169,6 @@ function buildRequest(request: SwapParams, options: SwapOptions): RelayQuoteRequ
     appFees,
   };
 
-  // Relay expects slippage values as percentage strings (e.g. "0.5" for 50 bps).
-  payload.slippageTolerance = (request.slippageBps / 100).toString();
-
   return payload;
 }
 


### PR DESCRIPTION
## Changes

Remove incorrect slippage tolerance calculation for relay.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change does not impact released packages (tests,docs,examples) (no release).