### PR TITLE
feat: enhanced selection pipeline

### DIFF
--- a/.changeset/wide-badgers-wonder.md
+++ b/.changeset/wide-badgers-wonder.md
@@ -1,0 +1,6 @@
+---
+"@spandex/react": minor
+"@spandex/core": minor
+---
+
+Give users more control around selection without having to write custom functions, which can result in better UX.

--- a/packages/core/lib/selectQuote.test.ts
+++ b/packages/core/lib/selectQuote.test.ts
@@ -29,6 +29,13 @@ const quoteSuccess: SuccessfulSimulatedQuote = {
   networkFee: 5_000n,
   txData: { to: "0x0", data: "0x0" },
   simulation: baseSimulation,
+  performance: {
+    latency: 100,
+    gasUsed: 5_000n,
+    outputAmount: 900_000n,
+    priceDelta: 0,
+    accuracy: 0,
+  },
 };
 
 const quoteFailure: SimulatedQuote = {
@@ -63,6 +70,11 @@ function makeSuccessfulQuote(
       ...quoteSuccess.simulation,
       outputAmount: simulationOutput,
       ...simulationOverride,
+    },
+    performance: {
+      ...quoteSuccess.performance,
+      outputAmount: simulationOutput,
+      ...(overrides.performance ?? {}),
     },
   } as SuccessfulSimulatedQuote;
 }
@@ -102,6 +114,128 @@ describe("selectQuote", () => {
     expect(output?.simulation.outputAmount).toBe(10n);
     expect(cancelled).toBe(true);
   }, 1_000);
+
+  it("custom selection composes firstN with bestPrice", async () => {
+    const pending = [
+      withDelay(makeSuccessfulQuote({ outputAmount: 12n }), 60),
+      withDelay(simulationFailure, 10),
+      withDelay(makeSuccessfulQuote({ outputAmount: 18n }), 30),
+      withDelay(makeSuccessfulQuote({ outputAmount: 99n }), 120),
+    ];
+
+    const output = await selectQuote({
+      strategy: {
+        collect: { type: "firstN", count: 2 },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+
+    expect(output).toBeDefined();
+    expect(output?.simulation.outputAmount).toBe(18n);
+  }, 1_000);
+
+  it("waits for the requested number of successful quotes", async () => {
+    const pending = [
+      withDelay(quoteFailure, 5),
+      withDelay(makeSuccessfulQuote({ outputAmount: 9n }), 50),
+      withDelay(simulationFailure, 10),
+      withDelay(makeSuccessfulQuote({ outputAmount: 11n }), 40),
+    ];
+
+    const output = await selectQuote({
+      strategy: {
+        collect: { type: "firstN", count: 2 },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+
+    expect(output).toBeDefined();
+    expect(output?.simulation.outputAmount).toBe(11n);
+  }, 1_000);
+
+  it("custom selection composes benchmark with bestPrice", async () => {
+    const pending = [
+      withDelay(makeSuccessfulQuote({ provider: "odos", outputAmount: 14n }), 20),
+      withDelay(makeSuccessfulQuote({ provider: "fabric", outputAmount: 11n }), 50),
+      withDelay(makeSuccessfulQuote({ provider: "relay", outputAmount: 30n }), 200),
+    ];
+
+    const output = await selectQuote({
+      strategy: {
+        collect: {
+          type: "benchmark",
+          provider: "fabric",
+          minQuotes: 2,
+        },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+
+    expect(output).toBeDefined();
+    expect(output?.provider).toBe("odos");
+    expect(output?.simulation.outputAmount).toBe(14n);
+  }, 1_000);
+
+  it("supports a custom collect function inside a strategy plan", async () => {
+    const pending = [
+      withDelay(makeSuccessfulQuote({ provider: "odos", outputAmount: 12n }), 20),
+      withDelay(makeSuccessfulQuote({ provider: "fabric", outputAmount: 18n }), 40),
+      withDelay(makeSuccessfulQuote({ provider: "relay", outputAmount: 30n }), 200),
+    ];
+
+    const output = await selectQuote({
+      strategy: {
+        collect: async (quotes) => {
+          const resolved = await Promise.all(quotes);
+          return resolved
+            .filter(
+              (quote): quote is SuccessfulSimulatedQuote =>
+                quote.success && quote.simulation.success && quote.provider !== "relay",
+            )
+            .slice(0, 2);
+        },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+
+    expect(output).toBeDefined();
+    expect(output?.provider).toBe("fabric");
+    expect(output?.simulation.outputAmount).toBe(18n);
+  }, 1_000);
+
+  it("supports a custom rank function inside a strategy plan", async () => {
+    const pending = [
+      Promise.resolve(
+        makeSuccessfulQuote({
+          provider: "fabric",
+          outputAmount: 1_000n,
+          simulation: { ...quoteSuccess.simulation, outputAmount: 1_000n },
+        }),
+      ),
+      Promise.resolve(
+        makeSuccessfulQuote({
+          provider: "odos",
+          outputAmount: 900n,
+          simulation: { ...quoteSuccess.simulation, outputAmount: 900n },
+        }),
+      ),
+    ];
+
+    const output = await selectQuote({
+      strategy: {
+        collect: { type: "all" },
+        rank: (quotes) => quotes[Math.floor(Math.random() * quotes.length)] ?? null,
+      },
+      quotes: pending,
+    });
+
+    expect(output).toBeDefined();
+    expect(["fabric", "odos"]).toContain(output?.provider);
+  });
 
   it("price selection - best simulated output relative to input is chosen", async () => {
     const pending = [
@@ -238,7 +372,74 @@ describe("selectQuote", () => {
     expect(output).toBeNull();
   });
 
+  it("returns null if firstN cannot collect enough successful quotes", async () => {
+    const pending = [Promise.resolve(quoteFailure), Promise.resolve(makeSuccessfulQuote({}))];
+    const output = await selectQuote({
+      strategy: {
+        collect: { type: "firstN", count: 2 },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+    expect(output).toBeNull();
+  });
+
+  it("returns null if benchmark criteria are not met", async () => {
+    const pending = [
+      Promise.resolve(makeSuccessfulQuote({ provider: "odos", outputAmount: 20n })),
+      Promise.resolve(quoteFailure),
+    ];
+    const output = await selectQuote({
+      strategy: {
+        collect: {
+          type: "benchmark",
+          provider: "fabric",
+          minQuotes: 2,
+        },
+        rank: "bestPrice",
+      },
+      quotes: pending,
+    });
+    expect(output).toBeNull();
+  });
+
   it("throws if args are bad", async () => {
     await expect(selectQuote({ strategy: "bestPrice", quotes: [] })).rejects.toThrow();
+    await expect(
+      selectQuote({
+        strategy: {
+          collect: { type: "firstN", count: 0 },
+          rank: "bestPrice",
+        },
+        quotes: [Promise.resolve(quoteSuccess)],
+      }),
+    ).rejects.toThrow("Collector firstN count must be a positive integer");
+    await expect(
+      selectQuote({
+        strategy: {
+          collect: { type: "firstN", count: 2 },
+          rank: "bestPrice",
+        },
+        quotes: [Promise.resolve(quoteSuccess)],
+      }),
+    ).rejects.toThrow("Collector firstN count cannot exceed the number of providers");
+    await expect(
+      selectQuote({
+        strategy: {
+          collect: { type: "benchmark", provider: "fabric", minQuotes: 0 },
+          rank: "bestPrice",
+        },
+        quotes: [Promise.resolve(quoteSuccess)],
+      }),
+    ).rejects.toThrow("Collector benchmark minQuotes must be a positive integer");
+    await expect(
+      selectQuote({
+        strategy: {
+          collect: { type: "all" },
+          rank: "first",
+        },
+        quotes: [Promise.resolve(quoteSuccess)],
+      }),
+    ).resolves.toBeDefined();
   });
 });

--- a/packages/core/lib/selectQuote.ts
+++ b/packages/core/lib/selectQuote.ts
@@ -1,5 +1,10 @@
 import type {
+  QuoteSelectionCollector,
+  QuoteSelectionCollectorSpec,
   QuoteSelectionFn,
+  QuoteSelectionPlan,
+  QuoteSelectionRanker,
+  QuoteSelectionRankerSpec,
   QuoteSelectionStrategy,
   SimulatedQuote,
   SimulatedQuoteSort,
@@ -62,50 +67,150 @@ function cancelPendingQuotes(quotes: Array<Promise<SimulatedQuote>>, reason: str
   collection.cancel?.(new Error(reason));
 }
 
-const quotedPrice: QuoteSelectionFn = async (
-  quotes: Array<Promise<SimulatedQuote>>,
-): Promise<SuccessfulSimulatedQuote | null> => {
-  const sorted = await resolveSuccessfulSimulatedQuotes({
-    quotes,
-    sort: withPriority(sortBySimulatedOutput),
-  });
-  return sorted[0] ?? null;
-};
+function assertPositiveInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+}
 
-const quotedGas: QuoteSelectionFn = async (
-  quotes: Array<Promise<SimulatedQuote>>,
-): Promise<SuccessfulSimulatedQuote | null> => {
-  const sorted = await resolveSuccessfulSimulatedQuotes({
-    quotes,
-    sort: withPriority(sortByGasUsed),
-  });
-  return sorted[0] ?? null;
-};
+function assertWithinProviderCount(value: number, max: number, label: string): void {
+  if (value > max) {
+    throw new Error(`${label} cannot exceed the number of providers`);
+  }
+}
 
-const priority: QuoteSelectionFn = async (
-  quotes: Array<Promise<SimulatedQuote>>,
-): Promise<SuccessfulSimulatedQuote | null> => {
-  const sorted = await resolveSuccessfulSimulatedQuotes({
-    quotes,
-    sort: withPriority(sortBySimulatedOutput),
-  });
-  return sorted[0] ?? null;
-};
-
-const fastest: QuoteSelectionFn = async (
-  quotes: Array<Promise<SimulatedQuote>>,
-): Promise<SuccessfulSimulatedQuote | null> => {
-  return Promise.any(
-    quotes.map(async (q) => {
-      const resolved = await q;
-      if (isSuccessfulSimulatedQuote(resolved)) {
-        cancelPendingQuotes(quotes, "Fastest quote selected");
-        return resolved;
+async function collectSuccessfulSimulatedQuotesUntil({
+  quotes,
+  shouldStop,
+  stopReason,
+}: {
+  quotes: Array<Promise<SimulatedQuote>>;
+  shouldStop: (quotes: SuccessfulSimulatedQuote[]) => boolean;
+  stopReason: string;
+}): Promise<SuccessfulSimulatedQuote[] | null> {
+  const pending = new Set(
+    quotes.map(async (quote) => {
+      try {
+        return await quote;
+      } catch {
+        return null;
       }
-      return Promise.reject("Failed quote simulation");
     }),
-  ).catch(() => null);
-};
+  );
+  const successfulQuotes: SuccessfulSimulatedQuote[] = [];
+
+  while (pending.size > 0) {
+    const next = await Promise.race(
+      [...pending].map(async (quote) => ({
+        promise: quote,
+        resolved: await quote,
+      })),
+    );
+    pending.delete(next.promise);
+
+    if (next.resolved && isSuccessfulSimulatedQuote(next.resolved)) {
+      successfulQuotes.push(next.resolved);
+
+      if (shouldStop(successfulQuotes)) {
+        cancelPendingQuotes(quotes, stopReason);
+        return successfulQuotes;
+      }
+    }
+  }
+
+  return null;
+}
+
+function rankQuotes(
+  quotes: SuccessfulSimulatedQuote[],
+  sort: SimulatedQuoteSort,
+): SuccessfulSimulatedQuote | null {
+  return [...quotes].sort(sort)[0] ?? null;
+}
+
+async function collectQuotes(
+  quotes: Array<Promise<SimulatedQuote>>,
+  collector: QuoteSelectionCollectorSpec,
+): Promise<SuccessfulSimulatedQuote[] | null> {
+  switch (collector.type) {
+    case "all":
+      return resolveSuccessfulSimulatedQuotes({ quotes });
+    case "firstN": {
+      assertPositiveInteger(collector.count, "Collector firstN count");
+      assertWithinProviderCount(collector.count, quotes.length, "Collector firstN count");
+      return collectSuccessfulSimulatedQuotesUntil({
+        quotes,
+        shouldStop: (successfulQuotes) => successfulQuotes.length >= collector.count,
+        stopReason: `Collected first ${collector.count} successful quote(s)`,
+      });
+    }
+    case "benchmark": {
+      const minQuotes = collector.minQuotes ?? 2;
+      assertPositiveInteger(minQuotes, "Collector benchmark minQuotes");
+      assertWithinProviderCount(minQuotes, quotes.length, "Collector benchmark minQuotes");
+      return collectSuccessfulSimulatedQuotesUntil({
+        quotes,
+        shouldStop: (successfulQuotes) =>
+          successfulQuotes.length >= minQuotes &&
+          successfulQuotes.some((quote) => quote.provider === collector.provider),
+        stopReason: `Collected benchmark provider ${collector.provider}`,
+      });
+    }
+  }
+}
+
+function rankCollectedQuotes(
+  quotes: SuccessfulSimulatedQuote[],
+  ranker: QuoteSelectionRankerSpec,
+): SuccessfulSimulatedQuote | null {
+  switch (ranker) {
+    case "first":
+      return quotes[0] ?? null;
+    case "bestPrice":
+      return rankQuotes(quotes, withPriority(sortBySimulatedOutput));
+    case "estimatedGas":
+      return rankQuotes(quotes, withPriority(sortByGasUsed));
+    case "priority":
+      return rankQuotes(quotes, withPriority(sortBySimulatedOutput));
+  }
+}
+
+function isCollectorSpec(
+  collector: QuoteSelectionCollector,
+): collector is QuoteSelectionCollectorSpec {
+  return typeof collector !== "function";
+}
+
+function isRankerSpec(ranker: QuoteSelectionRanker): ranker is QuoteSelectionRankerSpec {
+  return typeof ranker !== "function";
+}
+
+function toSelectionFn(strategy: QuoteSelectionStrategy): QuoteSelectionFn {
+  if (typeof strategy === "function") {
+    return strategy;
+  }
+
+  const plan: QuoteSelectionPlan =
+    typeof strategy === "string"
+      ? strategy === "fastest"
+        ? { collect: { type: "firstN", count: 1 }, rank: "first" }
+        : { collect: { type: "all" }, rank: strategy }
+      : strategy;
+
+  return async (
+    quotes: Array<Promise<SimulatedQuote>>,
+  ): Promise<SuccessfulSimulatedQuote | null> => {
+    const successfulQuotes = isCollectorSpec(plan.collect)
+      ? await collectQuotes(quotes, plan.collect)
+      : await plan.collect(quotes);
+    if (!successfulQuotes?.length) {
+      return null;
+    }
+    return isRankerSpec(plan.rank)
+      ? rankCollectedQuotes(successfulQuotes, plan.rank)
+      : plan.rank(successfulQuotes);
+  };
+}
 
 /**
  * Selects a winning quote from a set of simulated quote promises.
@@ -126,18 +231,5 @@ export async function selectQuote({
     throw new Error("No quotes provided to selectQuote");
   }
 
-  if (typeof strategy === "function") {
-    return strategy(quotes);
-  }
-
-  switch (strategy) {
-    case "fastest":
-      return fastest(quotes);
-    case "bestPrice":
-      return quotedPrice(quotes);
-    case "estimatedGas":
-      return quotedGas(quotes);
-    case "priority":
-      return priority(quotes);
-  }
+  return toSelectionFn(strategy)(quotes);
 }

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -696,6 +696,86 @@ export type SimulatedQuoteSort = (
 ) => number;
 
 /**
+ * Collector that waits for all simulated quotes to settle before ranking them.
+ */
+export type QuoteSelectionAllCollector = {
+  type: "all";
+};
+
+/**
+ * Collector that waits for the first `count` successful simulated quotes.
+ */
+export type QuoteSelectionFirstNCollector = {
+  type: "firstN";
+  count: number;
+};
+
+/**
+ * Collector that waits for a successful quote from a benchmark provider and at least
+ * `minQuotes` successful quotes overall.
+ */
+export type QuoteSelectionBenchmarkCollector = {
+  type: "benchmark";
+  provider: ProviderKey;
+  minQuotes?: number;
+};
+
+/**
+ * Built-in collector definitions used by composed selection plans.
+ */
+export type QuoteSelectionCollectorSpec =
+  | QuoteSelectionAllCollector
+  | QuoteSelectionFirstNCollector
+  | QuoteSelectionBenchmarkCollector;
+
+/**
+ * Collector function that chooses when enough successful quotes have been gathered.
+ *
+ * Returning `null` indicates that collection criteria were not met.
+ */
+export type QuoteSelectionCollectorFn = (
+  quotes: Array<Promise<SimulatedQuote>>,
+) => Promise<SuccessfulSimulatedQuote[] | null>;
+
+/**
+ * Built-in ranking modes that choose a winner from an already collected subset.
+ */
+export type QuoteSelectionRankerSpec = "first" | "bestPrice" | "estimatedGas" | "priority";
+
+/**
+ * Ranker function that picks a winner from an already collected subset of successful quotes.
+ */
+export type QuoteSelectionRankerFn = (
+  quotes: SuccessfulSimulatedQuote[],
+) => SuccessfulSimulatedQuote | null;
+
+/**
+ * Collector phase in a composed selection plan.
+ *
+ * This may be a built-in serializable collector spec or a custom collector function.
+ */
+export type QuoteSelectionCollector = QuoteSelectionCollectorSpec | QuoteSelectionCollectorFn;
+
+/**
+ * Ranking phase in a composed selection plan.
+ *
+ * This may be a built-in serializable ranking spec or a custom ranker function.
+ */
+export type QuoteSelectionRanker = QuoteSelectionRankerSpec | QuoteSelectionRankerFn;
+
+/**
+ * Strategy definition composed from a collection phase and a ranking phase.
+ *
+ * Each phase may use a built-in serializable spec or a custom function.
+ */
+export type QuoteSelectionPlan = {
+  /** Collection phase that decides when enough successful quotes are available. */
+  collect: QuoteSelectionCollector;
+  /** Ranking phase that chooses a winner from the collected subset. */
+  rank: QuoteSelectionRanker;
+};
+
+/**
  * Custom strategy function used to pick a winning quote.
  */
 export type QuoteSelectionFn = (
@@ -708,9 +788,9 @@ export type QuoteSelectionFn = (
 export type QuoteSelectionName = "fastest" | "bestPrice" | "estimatedGas" | "priority";
 
 /**
- * Strategy reference, either by name or via custom function.
+ * Strategy reference, either by name, serializable collector/ranker plan, or custom function.
  */
-export type QuoteSelectionStrategy = QuoteSelectionName | QuoteSelectionFn;
+export type QuoteSelectionStrategy = QuoteSelectionName | QuoteSelectionPlan | QuoteSelectionFn;
 
 /**
  * Aggregated pricing summary derived from multiple quotes.

--- a/packages/react/lib/hooks/useQuote.test.tsx
+++ b/packages/react/lib/hooks/useQuote.test.tsx
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { QuoteSelectionFn } from "@spandex/core";
+import { act } from "@testing-library/react";
 import { createPublicClient, http, type PublicClient } from "viem";
 import { base } from "viem/chains";
 import { TEST_ADDRESSES, TEST_CHAINS } from "../../test/constants.js";
@@ -177,6 +179,105 @@ describe("useQuote", () => {
       expect(result.current.isLoading).toBe(false);
       expect(result.current.data).toBeDefined();
       expect(result.current.data).toEqual("fabric");
+    });
+  });
+
+  it("should refetch when a custom strategy function reference changes", async () => {
+    const strategyTwo = (() => Promise.resolve(null)) as QuoteSelectionFn;
+    const strategyThree = (() => Promise.resolve(null)) as QuoteSelectionFn;
+
+    const { rerender } = renderHook(
+      ({ strategy }: { strategy: QuoteSelectionFn }) =>
+        useQuote({
+          swap: {
+            mode: "exactIn",
+            inputToken: TEST_ADDRESSES.usdc,
+            outputToken: TEST_ADDRESSES.weth,
+            inputAmount: 500_000_000n,
+            slippageBps: 100,
+          },
+          strategy,
+        }),
+      {
+        initialProps: {
+          strategy: strategyTwo,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(1);
+      expect(mockFetchQuote.mock.calls[0]?.[0]?.strategy).toBe(strategyTwo);
+    });
+
+    await act(async () => {
+      rerender({ strategy: strategyTwo });
+    });
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(1);
+      expect(mockFetchQuote.mock.calls[0]?.[0]?.strategy).toBe(strategyTwo);
+    });
+
+    await act(async () => {
+      rerender({ strategy: strategyThree });
+    });
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(2);
+      expect(mockFetchQuote.mock.calls[1]?.[0]?.strategy).toBe(strategyThree);
+    });
+  });
+
+  it("should not refetch when a strategy plan is structurally unchanged", async () => {
+    const { rerender } = renderHook(
+      ({ count }: { count: number }) =>
+        useQuote({
+          swap: {
+            mode: "exactIn",
+            inputToken: TEST_ADDRESSES.usdc,
+            outputToken: TEST_ADDRESSES.weth,
+            inputAmount: 500_000_000n,
+            slippageBps: 100,
+          },
+          strategy: {
+            collect: { type: "firstN", count },
+            rank: "bestPrice",
+          },
+        }),
+      {
+        initialProps: {
+          count: 2,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(1);
+      expect(mockFetchQuote.mock.calls[0]?.[0]?.strategy).toEqual({
+        collect: { type: "firstN", count: 2 },
+        rank: "bestPrice",
+      });
+    });
+
+    await act(async () => {
+      rerender({ count: 2 });
+    });
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      rerender({ count: 3 });
+    });
+
+    await waitFor(() => {
+      expect(mockFetchQuote).toHaveBeenCalledTimes(2);
+      expect(mockFetchQuote.mock.calls[1]?.[0]?.strategy).toEqual({
+        collect: { type: "firstN", count: 3 },
+        rank: "bestPrice",
+      });
     });
   });
 });

--- a/packages/react/lib/hooks/useQuote.ts
+++ b/packages/react/lib/hooks/useQuote.ts
@@ -1,6 +1,8 @@
 import {
   type ExactInSwapParams,
   getQuote,
+  type QuoteSelectionFn,
+  type QuoteSelectionPlan,
   type QuoteSelectionStrategy,
   type SuccessfulSimulatedQuote,
   type SwapParams,
@@ -18,6 +20,38 @@ type UseSwapParams = (
   chainId?: number;
   swapperAccount?: `0x${string}`;
 };
+
+const strategyIds = new WeakMap<QuoteSelectionFn, number>();
+const strategyPlanIds = new WeakMap<QuoteSelectionPlan, number>();
+let nextStrategyId = 1;
+
+function getStrategyKey(strategy: QuoteSelectionStrategy): QuoteSelectionStrategy | string {
+  if (typeof strategy === "string") {
+    return strategy;
+  }
+
+  if (typeof strategy === "object") {
+    if (typeof strategy.collect !== "function" && typeof strategy.rank !== "function") {
+      return strategy;
+    }
+
+    let id = strategyPlanIds.get(strategy);
+    if (!id) {
+      id = nextStrategyId++;
+      strategyPlanIds.set(strategy, id);
+    }
+
+    return `plan:${id}`;
+  }
+
+  let id = strategyIds.get(strategy);
+  if (!id) {
+    id = nextStrategyId++;
+    strategyIds.set(strategy, id);
+  }
+
+  return `custom:${id}`;
+}
 
 export type UseQuoteParams<TSelectData = SuccessfulSimulatedQuote | null> = {
   swap: UseSwapParams;
@@ -72,7 +106,7 @@ export function useQuote<TSelectData = SuccessfulSimulatedQuote | null>(
     staleTime: 10_000,
   } as UseQueryOptions<SuccessfulSimulatedQuote | null, Error, TSelectData>;
 
-  const strategyKey = typeof strategy === "string" ? strategy : "custom";
+  const strategyKey = getStrategyKey(strategy);
 
   const requirements = {
     queryKey: [

--- a/site/docs/pages/core/functions/getQuote.mdx
+++ b/site/docs/pages/core/functions/getQuote.mdx
@@ -64,15 +64,17 @@ Parameters defining the swap operation. See [SwapParams reference](/reference/Sw
 ### strategy
 `QuoteSelectionStrategy`
 
-Selection strategy used to pick a winning quote. Built-in strategy names:
+Selection strategy used to pick a winning quote.
 
 | Strategy | Waits for All | Selection Criteria | Best For |
 |----------|---------------|-------------------|----------|
 | `bestPrice` | ✓ | Highest simulated output | Price optimization |
 | `estimatedGas` | ✓ | Lowest simulated gas used | Gas efficiency |
 | `fastest` | ✗ | First success | Lowest latency |
-| `priority` | ✗ | Provider order | Failover chains |
+| `priority` | ✓ | Feature priority, then best price | Integrator-controlled preference |
 | Custom | Depends | Your logic | Special requirements |
+
+For tradeoffs and collector/ranker composition examples, see [Strategies](/core/strategies).
 
 Custom function signature:
 

--- a/site/docs/pages/core/functions/selectQuote.mdx
+++ b/site/docs/pages/core/functions/selectQuote.mdx
@@ -41,8 +41,10 @@ Strategy used to pick a winning quote.
 | `bestPrice` | ✓ | Highest simulated output | Price optimization |
 | `estimatedGas` | ✓ | Lowest simulated gas used | Gas efficiency |
 | `fastest` | ✗ | First success | Speed/latency |
-| `priority` | ✗ | Provider order | Fallback chains |
+| `priority` | ✓ | Feature priority, then best price | Integrator-controlled preference |
 | Custom | Depends | Your logic | Special requirements |
+
+For tradeoffs and collector/ranker composition examples, see [Strategies](/core/strategies).
 
 **Custom**
 ```ts

--- a/site/docs/pages/core/strategies.mdx
+++ b/site/docs/pages/core/strategies.mdx
@@ -1,0 +1,216 @@
+# Strategies
+
+Selection strategies decide when spanDEX stops waiting for quotes and how it picks a winner.
+
+## Built-In Strategies
+
+| Strategy | Waits for All | Selection Criteria | Best For |
+|----------|---------------|-------------------|----------|
+| `fastest` | ✗ | First successful quote | Lowest latency |
+| `bestPrice` | ✓ | Highest simulated output | Price optimization |
+| `estimatedGas` | ✓ | Lowest simulated gas used | Gas efficiency |
+| `priority` | ✓ | Feature priority, then best price | Integrator-controlled preference |
+
+## fastest
+
+Returns the first successful simulated quote.
+
+Pros:
+- Lowest latency.
+- Good default when execution speed matters more than quote quality.
+
+Cons:
+- Most exposed to adverse selection.
+- Ignores potentially better quotes that arrive slightly later.
+
+## bestPrice
+
+Waits for every provider to finish, then picks the highest simulated output.
+
+Pros:
+- Best price discovery across the full provider set.
+- Most direct choice when output amount is the primary objective.
+
+Cons:
+- Highest latency.
+- A slow provider delays selection.
+
+## estimatedGas
+
+Waits for every provider to finish, then picks the successful quote with the lowest simulated gas.
+
+Pros:
+- Useful when gas dominates the decision.
+- Avoids paying extra for marginal output improvements.
+
+Cons:
+- Can sacrifice output amount.
+- Same latency tradeoff as `bestPrice`.
+
+## priority
+
+Waits for every provider to finish, then prefers quotes with more activated features before using
+best price as the tie-breaker.
+
+Pros:
+- Useful when integrator features must be respected.
+- Lets configuration influence selection without fully overriding quality.
+
+Cons:
+- Can intentionally choose a worse price.
+- Requires understanding feature-priority tradeoffs.
+
+## Composing Collectors and Rankers
+
+For composed strategies, spanDEX supports a serializable plan object with two parts:
+
+- `collect` decides when enough successful quotes have arrived
+- `rank` decides how to choose a winner from the collected subset
+
+This keeps "when do we stop waiting?" separate from "how do we choose the winner?" while
+preserving the original custom function API.
+
+Each phase can use either a built-in spec or a custom function.
+
+### Collector Types
+
+```ts
+type QuoteSelectionCollector =
+  | { type: "all" }
+  | { type: "firstN"; count: number }
+  | { type: "benchmark"; provider: ProviderKey; minQuotes?: number }
+  | ((quotes: Array<Promise<SimulatedQuote>>) => Promise<SuccessfulSimulatedQuote[] | null>)
+```
+
+- `all` waits for all providers
+- `firstN` waits for the first `count` successful quotes
+- `benchmark` waits for a successful quote from a required provider and at least `minQuotes`
+  successful quotes total
+
+### Rankers
+
+```ts
+type QuoteSelectionRanker =
+  | "first"
+  | "bestPrice"
+  | "estimatedGas"
+  | "priority"
+  | ((quotes: SuccessfulSimulatedQuote[]) => SuccessfulSimulatedQuote | null);
+```
+
+The built-in `"fastest"` strategy is equivalent to:
+
+```ts
+{
+  collect: { type: "firstN", count: 1 },
+  rank: "first",
+}
+```
+
+### Strategy Plan
+
+```ts
+type QuoteSelectionPlan = {
+  collect: QuoteSelectionCollector;
+  rank: QuoteSelectionRanker;
+}
+```
+
+### Example: firstN + bestPrice
+
+This is the simplest example of a partial-collection strategy.
+
+```ts
+import { getQuote } from "@spandex/core";
+
+const quote = await getQuote({
+  config,
+  swap,
+  strategy: {
+    collect: { type: "firstN", count: 2 },
+    rank: "bestPrice",
+  },
+});
+```
+
+Pros:
+- Balances speed with some price discovery.
+- Can mitigate adverse selection compared with `fastest`.
+- Adapts naturally to other rankers like `estimatedGas`.
+
+Cons:
+- More likely to return no winner than `fastest`.
+- Still does not wait for the full provider set.
+
+Example:
+- With 3 providers and `firstN + bestPrice`, spanDEX can wait for the first 2 successful quotes,
+  then pick the better price between those 2.
+- If only 1 provider succeeds, no winner is selected and `getQuote` returns `null`.
+- If `count < 1` or `count` exceeds the number of providers, collection throws.
+
+### Example: benchmark + bestPrice
+
+```ts
+const quote = await getQuote({
+  config,
+  swap,
+  strategy: {
+    collect: {
+      type: "benchmark",
+      provider: "fabric",
+      minQuotes: 2,
+    },
+    rank: "bestPrice",
+  },
+});
+```
+
+This means:
+
+- wait for a successful `fabric` quote
+- also wait for at least 2 successful quotes total
+- then choose the best-priced quote among that collected subset
+
+If the benchmark provider never succeeds, no winner is selected and `getQuote` returns `null`.
+
+### Example: custom rank function
+
+This ranker stays purely price-first, then uses `performance.accuracy` as the tie-breaker. That
+gives the integrator "best price, but if two quotes are tied, prefer the one that was more
+accurate."
+
+```ts
+const quote = await getQuote({
+  config,
+  swap,
+  strategy: {
+    collect: { type: "all" },
+    rank: (quotes) => {
+      return [...quotes].sort((a, b) => {
+        if (a.simulation.outputAmount !== b.simulation.outputAmount) {
+          return a.simulation.outputAmount > b.simulation.outputAmount ? -1 : 1;
+        }
+
+        const accuracyA = a.performance.accuracy ?? Number.POSITIVE_INFINITY;
+        const accuracyB = b.performance.accuracy ?? Number.POSITIVE_INFINITY;
+        if (accuracyA === accuracyB) return 0;
+        return accuracyA < accuracyB ? -1 : 1;
+      })[0] ?? null;
+    },
+  },
+});
+```
+
+## Custom Selectors
+
+You can supply any custom selector function that matches the selection signature.
+
+```ts
+type QuoteSelectionFn = (
+  quotes: Array<Promise<SimulatedQuote>>
+) => Promise<SuccessfulSimulatedQuote | null>
+```
+
+In React, memoize function strategies so the query key stays stable across renders.
+
+Use this when the built-in strategies do not match your routing policy.

--- a/site/docs/pages/react/hooks/useQuote.mdx
+++ b/site/docs/pages/react/hooks/useQuote.mdx
@@ -51,7 +51,13 @@ connection if omitted) and optional `recipientAccount` (defaults to `swapperAcco
 
 ### strategy
 
-Defines how to choose the winning quote. Built-in strategies are `"fastest"`, `"bestPrice"`, `"estimatedGas"`, and `"priority"`. You can also supply a custom selection function.
+Defines how to choose the winning quote. Built-in strategies are `"fastest"`, `"bestPrice"`,
+`"estimatedGas"`, and `"priority"`. You can also supply a serializable strategy plan or a custom
+selection function.
+
+For strategy tradeoffs and collector/ranker composition examples, see [Strategies](/core/strategies).
+When using function strategies, or strategy plans that contain custom `collect` or `rank`
+functions, memoize them so the query key stays stable across renders.
 
 ### query
 

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
           link: "/core/getting-started",
         },
         {
+          text: "Strategies",
+          link: "/core/strategies",
+        },
+        {
           text: "Functions",
           items: [
             {


### PR DESCRIPTION
## Changes

Give users more control around selection without having to write custom functions, which can result in better UX.

* Break strategy into two concepts: collector and ranker
* Collectors determine how many and which quotes to collect (all, first 2, first 1, specific provider, etc)
* Rankers then take the resolved simulated quotes and choose the "best" one

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [] This change does not impact released packages (tests,docs,examples) (no release).