### PR TITLE
patchwork: rev packages, minor nits, add dynamic fee resolution

### DIFF
--- a/.changeset/peer-viem-wagmi.md
+++ b/.changeset/peer-viem-wagmi.md
@@ -1,0 +1,8 @@
+---
+"@spandex/core": patch
+"@spandex/react": patch
+---
+
+* Move viem, wagmi, and TanStack Query integration packages to peer dependencies so consumers provide the same client and provider packages used by their apps.
+* Add relay option for api key
+* Add per-swap dynamic fee resolution + preference for supporting providers

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -7,10 +7,10 @@
         "@changesets/cli": "^2.31.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.9",
-        "@types/bun": "^1.3.12",
+        "@biomejs/biome": "2.4.13",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.6.0",
-        "typescript": "^5.9.3",
+        "typescript": "6.0.3",
       },
     },
     "examples/hono": {
@@ -55,26 +55,26 @@
       },
       "devDependencies": {
         "@tanstack/devtools-vite": "0.6.0",
+        "@types/bun": "latest",
         "@types/node": "^22.10.2",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "6.0.1",
-        "typescript": "^5.7.2",
+        "typescript": "6.0.3",
         "vite": "8.0.3",
       },
     },
     "packages/core": {
       "name": "@spandex/core",
       "version": "0.7.1",
-      "dependencies": {
-        "viem": "^2.40",
-      },
       "devDependencies": {
         "@types/bun": "latest",
         "prool": "^0.2.1",
+        "viem": "^2.40",
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
+        "viem": ">=2 <3",
       },
       "optionalPeers": [
         "typescript",
@@ -85,22 +85,25 @@
       "version": "0.7.1",
       "dependencies": {
         "@spandex/core": "workspace:*",
-        "@tanstack/react-query": "^5.90.17",
-        "viem": "^2.40",
-        "wagmi": "^3.3.2",
       },
       "devDependencies": {
+        "@tanstack/react-query": "^5.90.17",
         "@testing-library/react": "^16.3.1",
         "@testing-library/react-hooks": "^8.0.1",
         "@types/bun": "latest",
         "@types/react": "^19.2.8",
         "happy-dom": "^20.3.0",
         "react-dom": "^19.2.3",
+        "viem": "^2.40",
+        "wagmi": "^3.3.2",
       },
       "peerDependencies": {
+        "@tanstack/react-query": ">=5 <6",
         "react": "^19",
         "react-dom": "^19",
-        "typescript": "^5.9.3",
+        "typescript": ">=5.0.4",
+        "viem": ">=2 <3",
+        "wagmi": ">=3 <4",
       },
       "optionalPeers": [
         "typescript",
@@ -117,13 +120,15 @@
         "@spandex/core": "workspace:*",
         "@spandex/react": "workspace:*",
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-query": "^5.90.17",
         "@types/react": "^19.2.0",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
         "tailwindcss": "^4.1.18",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "viem": "^2.40.1",
         "vocs": "^1.4.1",
+        "wagmi": "^3.3.2",
       },
     },
   },
@@ -176,23 +181,23 @@
 
     "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.13", "@biomejs/cli-darwin-x64": "2.4.13", "@biomejs/cli-linux-arm64": "2.4.13", "@biomejs/cli-linux-arm64-musl": "2.4.13", "@biomejs/cli-linux-x64": "2.4.13", "@biomejs/cli-linux-x64-musl": "2.4.13", "@biomejs/cli-win32-arm64": "2.4.13", "@biomejs/cli-win32-x64": "2.4.13" }, "bin": { "biome": "bin/biome" } }, "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.13", "", { "os": "linux", "cpu": "x64" }, "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.13", "", { "os": "linux", "cpu": "x64" }, "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.13", "", { "os": "win32", "cpu": "x64" }, "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 
@@ -1672,9 +1677,9 @@
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "react-error-boundary": ["react-error-boundary@3.1.4", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA=="],
 
@@ -1884,7 +1889,7 @@
 
     "twoslash-protocol": ["twoslash-protocol@0.3.6", "", {}, "sha512-FHGsJ9Q+EsNr5bEbgG3hnbkvEBdW5STgPU824AHUjB4kw0Dn4p8tABT7Ncg1Ie6V0+mDg3Qpy41VafZXcQhWMA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 

--- a/examples/hono/tsconfig.json
+++ b/examples/hono/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "types": ["bun"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -36,11 +36,12 @@
   },
   "devDependencies": {
     "@tanstack/devtools-vite": "0.6.0",
+    "@types/bun": "latest",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "6.0.1",
-    "typescript": "^5.7.2",
+    "typescript": "6.0.3",
     "vite": "8.0.3"
   }
 }

--- a/examples/react/src/components/TokenDrawer/index.tsx
+++ b/examples/react/src/components/TokenDrawer/index.tsx
@@ -53,7 +53,7 @@ function ContractAddressInput() {
 
   // once we have the token, set it in context and close the drawer
   useEffect(() => {
-    if (!inputValid || !data || processedRef.current === inputValue || !!error) return;
+    if (!inputValid || !data || processedRef.current === inputValue || error) return;
 
     const [symbolResult, decimalsResult] = data;
 

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -4,8 +4,8 @@
     "target": "ES2022",
     "jsx": "react-jsx",
     "module": "ESNext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["vite/client"],
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun", "node", "vite/client"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.13",
-    "@biomejs/biome": "2.4.9",
-    "typescript": "^5.9.3",
+    "@biomejs/biome": "2.4.13",
+    "typescript": "6.0.3",
     "@types/node": "^25.6.0"
   },
   "dependencies": {

--- a/packages/core/lib/aggregators/0x.test.ts
+++ b/packages/core/lib/aggregators/0x.test.ts
@@ -41,6 +41,57 @@ describe("0x API test", () => {
     }
   }, 30_000);
 
+  it("passes fee token preference as swapFeeToken", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestedUrl: URL | undefined;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url;
+      requestedUrl = new URL(url);
+      return new Response(
+        JSON.stringify({
+          allowanceTarget: "0x0000000000001ff3684f28c67538d4d072c22734",
+          buyAmount: "900000",
+          sellAmount: "1000000",
+          sellToken: defaultSwapParams.inputToken,
+          totalNetworkFee: "1",
+          transaction: {
+            to: "0x0000000000000000000000000000000000000001",
+            data: "0x",
+            value: "0",
+          },
+          route: {
+            tokens: [
+              { address: defaultSwapParams.inputToken, symbol: "USDC" },
+              { address: defaultSwapParams.outputToken, symbol: "WETH" },
+            ],
+            fills: [
+              {
+                from: defaultSwapParams.inputToken,
+                to: defaultSwapParams.outputToken,
+                source: "Mock",
+                proportionBps: "10000",
+              },
+            ],
+          },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      await zeroX({ apiKey: "test" }).fetchQuote(defaultSwapParams, {
+        integratorFeeFn: async (params) => ({
+          feeAddress: "0xFee00000000000000000000000000000000000fee",
+          swapFeeBps: 20,
+          tokenPreference: params.inputToken,
+        }),
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requestedUrl?.searchParams.get("swapFeeToken")).toBe(defaultSwapParams.inputToken);
+  });
+
   it("supports native in", async () => {
     const quote = await recordOutput("0x/native-input", async () => {
       return zeroX({ apiKey: process.env.ZEROX_API_KEY || "" }).fetchQuote(nativeInputSwap);

--- a/packages/core/lib/aggregators/0x.ts
+++ b/packages/core/lib/aggregators/0x.ts
@@ -155,6 +155,9 @@ function extractQueryParams(
     result.swapFeeRecipient = options.integratorFeeAddress;
     if (options.integratorSwapFeeBps !== undefined) {
       result.swapFeeBps = options.integratorSwapFeeBps.toString();
+      if (options.integratorFeeTokenPreference !== undefined) {
+        result.swapFeeToken = options.integratorFeeTokenPreference;
+      }
     }
     if (options.integratorSurplusBps) {
       result.tradeSurplusRecipient = options.integratorFeeAddress;

--- a/packages/core/lib/aggregators/index.ts
+++ b/packages/core/lib/aggregators/index.ts
@@ -1,4 +1,5 @@
 import type { Address } from "viem";
+import { resolveSwapOptions } from "../resolveOptions.js";
 import {
   type AggregationOptions,
   type AggregatorFeature,
@@ -89,6 +90,16 @@ export abstract class Aggregator<C extends ProviderConfig = ProviderConfig> {
     return token;
   }
 
+  protected resolveTokenOptions(options: SwapOptions): SwapOptions {
+    if (!options.integratorFeeTokenPreference) {
+      return options;
+    }
+    return {
+      ...options,
+      integratorFeeTokenPreference: this.resolveTokenAddress(options.integratorFeeTokenPreference),
+    };
+  }
+
   /**
    * Optional attributes provided by the integrator for logging and analytics purposes.
    */
@@ -129,16 +140,18 @@ export abstract class Aggregator<C extends ProviderConfig = ProviderConfig> {
    * @returns Successful or failed quote result.
    */
   async fetchQuote(params: SwapParams, options?: AggregationOptions): Promise<Quote> {
+    const resolvedOptions = await resolveSwapOptions(params, options);
     const resolvedParams: SwapParams = {
       ...params,
       inputToken: this.resolveTokenAddress(params.inputToken),
       outputToken: this.resolveTokenAddress(params.outputToken),
     };
 
+    const providerOptions = this.resolveTokenOptions(resolvedOptions);
     const effectiveOptions =
       this.config.timeoutMs === undefined
-        ? options
-        : { ...(options ?? {}), deadlineMs: this.config.timeoutMs };
+        ? providerOptions
+        : { ...providerOptions, deadlineMs: this.config.timeoutMs };
     const { delayMs, numRetries, deadlineMs } = resolveTimingControls(effectiveOptions);
 
     const quoteCall = async () => {

--- a/packages/core/lib/aggregators/relay.test.ts
+++ b/packages/core/lib/aggregators/relay.test.ts
@@ -30,6 +30,45 @@ describe("Relay", () => {
     }
   }, 30_000);
 
+  it("passes the api key header when configured", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestHeaders: Headers | undefined;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestHeaders = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          steps: [
+            {
+              id: "swap",
+              items: [
+                {
+                  data: {
+                    to: "0x0000000000000000000000000000000000000001",
+                    data: "0x",
+                    value: "0",
+                  },
+                },
+              ],
+            },
+          ],
+          details: {
+            currencyIn: { amount: defaultSwapParams.inputAmount.toString() },
+            currencyOut: { amount: "900000" },
+          },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      await relay({ apiKey: "relay-test-key" }).fetchQuote(defaultSwapParams);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requestHeaders?.get("x-api-key")).toBe("relay-test-key");
+    expect(requestHeaders?.get("Content-Type")).toBe("application/json");
+  });
+
   it("supports native in", async () => {
     const quote = await recordOutput("relay/native-input", async () => {
       return relay().fetchQuote(nativeInputSwap);

--- a/packages/core/lib/aggregators/relay.ts
+++ b/packages/core/lib/aggregators/relay.ts
@@ -21,6 +21,7 @@ import { Aggregator } from "./index.js";
  */
 export type RelayConfig = ProviderConfig & {
   url?: string;
+  apiKey?: string;
 };
 
 /**
@@ -58,7 +59,7 @@ export class RelayAggregator extends Aggregator<RelayConfig> {
     const payload = buildRequest(request, options);
     const response = await fetch(`${this.config.url || "https://api.relay.link"}/quote`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: this.headers(),
       body: JSON.stringify(payload),
     });
 
@@ -129,6 +130,18 @@ export class RelayAggregator extends Aggregator<RelayConfig> {
       metrics,
       ...mode,
     };
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.config.apiKey) {
+      headers["x-api-key"] = this.config.apiKey;
+    }
+
+    return headers;
   }
 }
 

--- a/packages/core/lib/createConfig.test.ts
+++ b/packages/core/lib/createConfig.test.ts
@@ -20,4 +20,33 @@ describe("createConfig", () => {
     expect(config.aggregators.length).toEqual(1);
     expect(config.aggregators[0]?.name()).toEqual("0x");
   });
+
+  it("supports dynamic integrator fee configuration", async () => {
+    const config = createConfig({
+      providers: [zeroX({ apiKey: "test" })],
+      options: {
+        integratorFeeFn: async () => ({
+          feeAddress: "0xFee00000000000000000000000000000000000fee",
+          swapFeeBps: 20,
+        }),
+      },
+    });
+
+    expect(config.options.integratorFeeFn).toBeDefined();
+  });
+
+  it("throws when dynamic and static fee options are combined", async () => {
+    expect(() => {
+      createConfig({
+        providers: [zeroX({ apiKey: "test" })],
+        options: {
+          integratorFeeFn: async () => ({
+            feeAddress: "0xFee00000000000000000000000000000000000fee",
+            swapFeeBps: 20,
+          }),
+          integratorSwapFeeBps: 20,
+        } as never,
+      });
+    }).toThrow(/cannot be combined/);
+  });
 });

--- a/packages/core/lib/createConfig.ts
+++ b/packages/core/lib/createConfig.ts
@@ -4,6 +4,7 @@ import type { Aggregator } from "./aggregators/index.js";
 import { kyberswap } from "./aggregators/kyber.js";
 import { nordstern } from "./aggregators/nordstern.js";
 import { odos } from "./aggregators/odos.js";
+import { validateStaticFeeOptions } from "./resolveOptions.js";
 import type {
   AggregationOptions,
   ConfigParams,
@@ -119,21 +120,5 @@ function createClientLookupFunction(
 }
 
 function validateOptions(options: AggregationOptions): void {
-  if (
-    ((options.integratorSwapFeeBps || 0) > 0 || (options.integratorSurplusBps || 0) > 0) &&
-    !options.integratorFeeAddress
-  ) {
-    throw new Error(
-      "Swap fees or surplus bps provided without an integrator fee address. Set `integratorFeeAddress` in AggregationOptions.",
-    );
-  }
-  if (
-    options.integratorFeeAddress &&
-    !options.integratorSwapFeeBps &&
-    !options.integratorSurplusBps
-  ) {
-    throw new Error(
-      "Integrator fee address provided without swap fees or surplus bps. Set `integratorSwapFeeBps` or `integratorSurplusBps` in AggregationOptions.",
-    );
-  }
+  validateStaticFeeOptions(options);
 }

--- a/packages/core/lib/prepareQuotes.test.ts
+++ b/packages/core/lib/prepareQuotes.test.ts
@@ -84,4 +84,56 @@ describe("prepareQuotes", () => {
     expect(quotes).toHaveLength(1);
     expect(quotes[0]?.provider).toBe("relay");
   });
+
+  it("resolves dynamic integrator fees once per swap before fetching provider quotes", async () => {
+    const first = new MockAggregator(quoteSuccess, {
+      features: ["exactIn", "integratorFees"],
+    });
+    const second = new MockAggregator(quoteSuccess, {
+      features: ["exactIn"],
+    });
+    let calls = 0;
+    const config: Config = createConfig({
+      providers: [first, second],
+      options: {
+        integratorFeeFn: async (params) => {
+          calls++;
+          expect(params).toMatchObject({
+            chainId: 8453,
+            inputAmount: 500_000_000n,
+          });
+          return {
+            feeAddress: "0xFee00000000000000000000000000000000000fee",
+            swapFeeBps: 25,
+            tokenPreference: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          };
+        },
+      },
+    });
+
+    const prepared = await prepareQuotes({
+      config,
+      swap: {
+        chainId: 8453,
+        inputToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        outputToken: "0x4200000000000000000000000000000000000006",
+        inputAmount: 500_000_000n,
+        slippageBps: 100,
+        swapperAccount: "0xdead00000000000000000000000000000000beef",
+        mode: "exactIn",
+      },
+      mapFn: async (quote: Quote) => quote,
+    });
+
+    const quotes = await Promise.all(prepared);
+    expect(calls).toBe(1);
+    expect(first.lastOptions).toMatchObject({
+      integratorFeeAddress: "0xFee00000000000000000000000000000000000fee",
+      integratorSwapFeeBps: 25,
+      integratorFeeTokenPreference: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    });
+    expect(second.lastOptions?.integratorSwapFeeBps).toBe(25);
+    expect(quotes[0]?.success && quotes[0].activatedFeatures).toEqual(["integratorFees"]);
+    expect(quotes[1]?.success && quotes[1].activatedFeatures).toEqual([]);
+  });
 });

--- a/packages/core/lib/prepareQuotes.ts
+++ b/packages/core/lib/prepareQuotes.ts
@@ -1,5 +1,6 @@
 import type { Config } from "./createConfig.js";
-import type { AggregationOptions, AggregatorFeature, Quote, SwapParams } from "./types.js";
+import { resolveSwapOptions } from "./resolveOptions.js";
+import type { AggregatorFeature, Quote, SwapOptions, SwapParams } from "./types.js";
 import { isCrossChain } from "./util/helpers.js";
 
 /**
@@ -27,7 +28,7 @@ export async function prepareQuotes<T>({
     );
   }
 
-  const options = config.options;
+  const options = await resolveSwapOptions(swap, config.options);
 
   // Required features for this request (hard filters)
   const requiredFeatures = queryFeatures(swap);
@@ -50,7 +51,7 @@ export async function prepareQuotes<T>({
   );
 }
 
-function feeFeatures(options?: AggregationOptions): AggregatorFeature[] {
+function feeFeatures(options?: SwapOptions): AggregatorFeature[] {
   const features: AggregatorFeature[] = [];
   if ((options?.integratorSwapFeeBps || 0) > 0) {
     features.push("integratorFees");

--- a/packages/core/lib/resolveOptions.ts
+++ b/packages/core/lib/resolveOptions.ts
@@ -1,0 +1,103 @@
+import type {
+  AggregationOptions,
+  FeeSettings,
+  ResolvedFeeOptions,
+  StaticFeeOptions,
+  SwapOptions,
+  SwapParams,
+  TimingOptions,
+} from "./types.js";
+
+/**
+ * Resolves static or dynamic aggregation options into the static shape providers consume.
+ */
+export async function resolveSwapOptions(
+  swap: SwapParams,
+  options?: AggregationOptions | SwapOptions,
+): Promise<SwapOptions> {
+  if (!options) {
+    return {};
+  }
+
+  const timing = timingOptions(options);
+  if (!options.integratorFeeFn) {
+    const resolved = { ...timing, ...staticFeeOptions(options) };
+    validateFeeOptions(resolved);
+    return resolved;
+  }
+
+  const feeSettings = normalizeFeeSettings(await options.integratorFeeFn(swap));
+  const resolved = { ...timing, ...feeSettings };
+  validateFeeOptions(resolved);
+  return resolved;
+}
+
+export function validateStaticFeeOptions(options: AggregationOptions): void {
+  if (options.integratorFeeFn) {
+    const staticKeys: Array<keyof StaticFeeOptions> = [
+      "integratorFeeAddress",
+      "integratorSwapFeeBps",
+      "integratorSurplusBps",
+      "integratorSurplusAddress",
+    ];
+    const configuredStaticKeys = staticKeys.filter((key) => options[key] !== undefined);
+    if (configuredStaticKeys.length > 0) {
+      throw new Error("`integratorFeeFn` cannot be combined with static integrator fee options.");
+    }
+    return;
+  }
+
+  validateFeeOptions(options);
+}
+
+function timingOptions(options: TimingOptions): TimingOptions {
+  return {
+    deadlineMs: options.deadlineMs,
+    numRetries: options.numRetries,
+    initialRetryDelayMs: options.initialRetryDelayMs,
+  };
+}
+
+function staticFeeOptions(options: ResolvedFeeOptions): ResolvedFeeOptions {
+  return {
+    integratorFeeAddress: options.integratorFeeAddress,
+    integratorSwapFeeBps: options.integratorSwapFeeBps,
+    integratorSurplusBps: options.integratorSurplusBps,
+    integratorSurplusAddress: options.integratorSurplusAddress,
+    integratorFeeTokenPreference: options.integratorFeeTokenPreference,
+  };
+}
+
+function normalizeFeeSettings(settings: FeeSettings | null | undefined): ResolvedFeeOptions {
+  if (!settings) {
+    return {};
+  }
+
+  return {
+    integratorFeeAddress: settings.feeAddress,
+    integratorSwapFeeBps: settings.swapFeeBps,
+    integratorSurplusBps: settings.surplusFeeBps,
+    integratorSurplusAddress: settings.surplusAddress,
+    integratorFeeTokenPreference: settings.tokenPreference,
+  };
+}
+
+function validateFeeOptions(options: StaticFeeOptions): void {
+  if (
+    ((options.integratorSwapFeeBps || 0) > 0 || (options.integratorSurplusBps || 0) > 0) &&
+    !options.integratorFeeAddress
+  ) {
+    throw new Error(
+      "Swap fees or surplus bps provided without an integrator fee address. Set `integratorFeeAddress` in AggregationOptions.",
+    );
+  }
+  if (
+    options.integratorFeeAddress &&
+    !options.integratorSwapFeeBps &&
+    !options.integratorSurplusBps
+  ) {
+    throw new Error(
+      "Integrator fee address provided without swap fees or surplus bps. Set `integratorSwapFeeBps` or `integratorSurplusBps` in AggregationOptions.",
+    );
+  }
+}

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -479,9 +479,42 @@ export type TimingOptions = {
 };
 
 /**
- * Options for configuring integrator fees and surplus sharing.
+ * Fee settings returned from a dynamic integrator fee function.
  */
-export type FeeOptions = {
+export type FeeSettings = {
+  /**
+   * Address that should receive the integrator fee.
+   */
+  feeAddress: Address;
+  /**
+   * Swap fee for the integrator (in basis points).
+   */
+  swapFeeBps?: number;
+  /**
+   * Surplus share for the integrator (in basis points).
+   */
+  surplusFeeBps?: number;
+  /**
+   * Address that should receive the integrator surplus. Defaults to `feeAddress` if not specified.
+   */
+  surplusAddress?: Address;
+  /**
+   * Preferred token address for providers that support fee-token selection.
+   */
+  tokenPreference?: Address;
+};
+
+/**
+ * Dynamic function for selecting integrator fee settings from the swap request.
+ */
+export type IntegratorFeeFn = (
+  params: SwapParams,
+) => FeeSettings | null | undefined | Promise<FeeSettings | null | undefined>;
+
+/**
+ * Static options for configuring integrator fees and surplus sharing.
+ */
+export type StaticFeeOptions = {
   /**
    * Address that should receive the integrator fee.
    */
@@ -498,12 +531,45 @@ export type FeeOptions = {
    * Address that should receive the integrator surplus. Defaults to `integratorFeeAddress` if not specified.
    */
   integratorSurplusAddress?: Address;
+  /**
+   * Dynamic fee functions are mutually exclusive with static integrator fee options.
+   */
+  integratorFeeFn?: never;
 };
 
 /**
- * Optional parameters for aggregator quote requests.
+ * Dynamic options for selecting integrator fees at swap time.
  */
-export type SwapOptions = FeeOptions;
+export type DynamicFeeOptions = {
+  /**
+   * Function invoked once per swap request to determine fee settings from the swap parameters.
+   */
+  integratorFeeFn: IntegratorFeeFn;
+  integratorFeeAddress?: never;
+  integratorSwapFeeBps?: never;
+  integratorSurplusBps?: never;
+  integratorSurplusAddress?: never;
+};
+
+/**
+ * Options for configuring integrator fees and surplus sharing.
+ */
+export type FeeOptions = StaticFeeOptions | DynamicFeeOptions;
+
+/**
+ * Resolved fee options passed to providers after dynamic fee settings are evaluated.
+ */
+export type ResolvedFeeOptions = StaticFeeOptions & {
+  /**
+   * Preferred token address for providers that support fee-token selection.
+   */
+  integratorFeeTokenPreference?: Address;
+};
+
+/**
+ * Resolved parameters for provider quote requests.
+ */
+export type SwapOptions = TimingOptions & ResolvedFeeOptions;
 
 /**
  * Combined aggregation options.

--- a/packages/core/lib/util/netOutputs.test.ts
+++ b/packages/core/lib/util/netOutputs.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import {
-  defaultSwapParams,
-  recordedSimulation,
-  testConfig,
-  USDC_WHALE,
-} from "packages/core/test/utils.js";
 import type { Address } from "viem";
+import { defaultSwapParams, recordedSimulation, testConfig, USDC_WHALE } from "../../test/utils.js";
 import { zeroX } from "../aggregators/0x.js";
 import { fabric } from "../aggregators/fabric.js";
 import { kyberswap } from "../aggregators/kyber.js";

--- a/packages/core/lib/util/performance.test.ts
+++ b/packages/core/lib/util/performance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { recordOutput, testConfig, usdcBalanceSwap } from "packages/core/test/utils.js";
+import { recordOutput, testConfig, usdcBalanceSwap } from "../../test/utils.js";
 import { fabric } from "../aggregators/fabric.js";
 import { kyberswap } from "../aggregators/kyber.js";
 import { odos } from "../aggregators/odos.js";

--- a/packages/core/lib/wire/proxy.test.ts
+++ b/packages/core/lib/wire/proxy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { defaultSwapParams, recordedQuotes, testConfig } from "packages/core/test/utils.js";
 import type { Address } from "viem";
+import { defaultSwapParams, recordedQuotes, testConfig } from "../../test/utils.js";
 import { fabric } from "../aggregators/fabric.js";
 import { createConfig } from "../createConfig.js";
 import { getQuote } from "../getQuote.js";

--- a/packages/core/lib/wire/streams.test.ts
+++ b/packages/core/lib/wire/streams.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { defaultSwapParams, testConfig } from "packages/core/test/utils.js";
+import { defaultSwapParams, testConfig } from "../../test/utils.js";
 import { fabric } from "../aggregators/fabric.js";
 import { relay } from "../aggregators/relay.js";
 import { prepareQuotes } from "../prepareQuotes.js";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,17 +48,16 @@
     "README.md"
   ],
   "scripts": {
-    "build": "bun ../../scripts/build-packages.ts core"
+    "build": "bun --cwd ../.. ./scripts/build-packages.ts core"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "prool": "^0.2.1"
-  },
-  "dependencies": {
+    "prool": "^0.2.1",
     "viem": "^2.40"
   },
   "peerDependencies": {
-    "typescript": ">=5.0.4"
+    "typescript": ">=5.0.4",
+    "viem": ">=2 <3"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -10,6 +10,7 @@ import type {
   Quote,
   SuccessfulQuote,
   SuccessfulSimulatedQuote,
+  SwapOptions,
   SwapParams,
 } from "../lib/types.js";
 
@@ -78,6 +79,7 @@ export class MockAggregator extends Aggregator {
     };
   }
   private counter = 0;
+  private capturedOptions: SwapOptions | undefined;
   constructor(
     private readonly quote: Quote,
     private readonly overrides: MockOverrides = {},
@@ -89,6 +91,10 @@ export class MockAggregator extends Aggregator {
 
   get count() {
     return this.counter;
+  }
+
+  get lastOptions() {
+    return this.capturedOptions;
   }
 
   name(): ProviderKey {
@@ -103,8 +109,9 @@ export class MockAggregator extends Aggregator {
     return this.overrides.features || ["exactIn"];
   }
 
-  async tryFetchQuote(_: SwapParams): Promise<SuccessfulQuote> {
+  async tryFetchQuote(_: SwapParams, options: SwapOptions): Promise<SuccessfulQuote> {
     this.counter++;
+    this.capturedOptions = options;
     if (this.overrides.delay) {
       await new Promise((resolve) => setTimeout(resolve, this.overrides.delay));
     }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
-    "rootDir": "./",
-    "baseUrl": "./"
+    "rootDir": "./"
   },
   "include": ["./**/*.ts"],
   "exclude": ["dist", "node_modules", "**/*.test.ts", "test"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,27 +49,30 @@
     "README.md"
   ],
   "scripts": {
-    "build": "bun ../../scripts/build-packages.ts wagmi",
+    "build": "bun --cwd ../.. ./scripts/build-packages.ts react",
     "test": "bun test --preload ./test-setup.ts"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.1",
     "@testing-library/react-hooks": "^8.0.1",
+    "@tanstack/react-query": "^5.90.17",
     "@types/bun": "latest",
     "@types/react": "^19.2.8",
     "happy-dom": "^20.3.0",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "viem": "^2.40",
+    "wagmi": "^3.3.2"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.90.17",
-    "@spandex/core": "workspace:*",
-    "wagmi": "^3.3.2",
-    "viem": "^2.40"
+    "@spandex/core": "workspace:*"
   },
   "peerDependencies": {
+    "@tanstack/react-query": ">=5 <6",
     "react": "^19",
     "react-dom": "^19",
-    "typescript": "^5.9.3"
+    "typescript": ">=5.0.4",
+    "viem": ">=2 <3",
+    "wagmi": ">=3 <4"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "rootDir": "./",
-    "baseUrl": "./",
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.test.tsx", "test*"]

--- a/scripts/build-packages.ts
+++ b/scripts/build-packages.ts
@@ -143,7 +143,7 @@ function buildOutputs(pkg: PackageInfo): void {
     "--module",
     "CommonJS",
     "--moduleResolution",
-    "Node10",
+    "Bundler",
     "--target",
     "ES2021",
     "--outDir",

--- a/site/docs/pages/configuration/fees.mdx
+++ b/site/docs/pages/configuration/fees.mdx
@@ -35,6 +35,7 @@ spanDEX supports two integrator fee-capture controls for applications that sourc
 
 - Fixed swap fee (`integratorSwapFeeBps`)
 - Surplus share (`integratorSurplusBps`)
+- Dynamic swap-time fee selection (`integratorFeeFn`)
 
 These requests are passed optimistically to providers. Each quote reports `activatedFeatures` so
 selection can prefer quotes that actually activated requested features.
@@ -81,6 +82,60 @@ const config = createConfig({
   },
 });
 ```
+
+## Dynamic Fee Decisions
+
+Use `integratorFeeFn` when fee settings depend on the swap route, token pair, chain, user, or
+amount. The function runs once per swap request before provider quote requests are sent, and the
+returned settings are forwarded to providers using the same fee controls as static configuration.
+
+```ts
+import { createConfig, zeroX } from "@spandex/core";
+
+const baseTokenPreferenceStack = [
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC
+  "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2", // USDT
+  "0x4200000000000000000000000000000000000006", // WETH
+  "0x0000000000000000000000000000000000000000", // ETH
+  "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf", // cbBTC
+] as const;
+
+const config = createConfig({
+  providers: [zeroX({ apiKey: "YOUR_0X_API_KEY" })],
+  options: {
+    integratorFeeFn: async (swap) => {
+      if (swap.chainId !== 8453) {
+        return undefined;
+      }
+
+      const inputIndex = baseTokenPreferenceStack.findIndex(
+        (token) => token.toLowerCase() === swap.inputToken.toLowerCase(),
+      );
+      const outputIndex = baseTokenPreferenceStack.findIndex(
+        (token) => token.toLowerCase() === swap.outputToken.toLowerCase(),
+      );
+
+      const selectedToken =
+        inputIndex >= 0 && (outputIndex < 0 || inputIndex <= outputIndex)
+          ? baseTokenPreferenceStack[inputIndex]
+          : baseTokenPreferenceStack[outputIndex];
+
+      if (!selectedToken) {
+        return undefined;
+      }
+
+      return {
+        feeAddress: "0xFee00000000000000000000000000000000000fee",
+        swapFeeBps: 10,
+        tokenPreference: selectedToken,
+      };
+    },
+  },
+});
+```
+
+`integratorFeeFn` is mutually exclusive with static fee settings like `integratorFeeAddress` and
+`integratorSwapFeeBps`. Return `null` or `undefined` to request no integrator fee for a swap.
 
 ## Integrator Fee Support by Provider
 

--- a/site/docs/pages/installation.mdx
+++ b/site/docs/pages/installation.mdx
@@ -22,18 +22,18 @@ pnpm i viem @spandex/core
 
 ## React
 
-`@spandex/react` provides React hooks for integrating spanDEX into your React applications. It depends on `wagmi`.
+`@spandex/react` provides React hooks for integrating spanDEX into your React applications. It depends on `viem`, `wagmi`, and TanStack Query.
 
 :::code-group
 
 ```bash [npm]
-npm i wagmi @spandex/react
+npm i viem wagmi @tanstack/react-query @spandex/react
 ```
 ```bash [bun]
-bun i wagmi @spandex/react
+bun i viem wagmi @tanstack/react-query @spandex/react
 ```
 ```bash [pnpm]
-pnpm i wagmi @spandex/react
+pnpm i viem wagmi @tanstack/react-query @spandex/react
 ```
 
 :::

--- a/site/docs/pages/providers/0x.mdx
+++ b/site/docs/pages/providers/0x.mdx
@@ -31,3 +31,9 @@ export const config = createConfig({
   ],
 });
 ```
+
+## Fee Token Preference
+
+0x supports fee-token selection through `swapFeeToken`. spanDEX forwards
+dynamic `tokenPreference` from `integratorFeeFn` to that field when an integrator swap fee is
+configured. 0x requires the token to be either the sell token or buy token.

--- a/site/docs/pages/providers/relay.mdx
+++ b/site/docs/pages/providers/relay.mdx
@@ -15,6 +15,8 @@ import { createConfig, relay } from "@spandex/core";
 export const config = createConfig({
   providers: [
     relay({
+      // Optional
+      apiKey: "YOUR_RELAY_API_KEY",
       // Optional, override the API base URL
       url: undefined,
     }),

--- a/site/docs/pages/react/getting-started.mdx
+++ b/site/docs/pages/react/getting-started.mdx
@@ -8,15 +8,15 @@ Install the core library:
 
 :::code-group
 ```bash [npm]
-npm i wagmi @spandex/react
+npm i viem wagmi @tanstack/react-query @spandex/react
 ```
 
 ```bash [bun]
-bun i wagmi @spandex/react
+bun i viem wagmi @tanstack/react-query @spandex/react
 ```
 
 ```bash [pnpm]
-pnpm i wagmi @spandex/react
+pnpm i viem wagmi @tanstack/react-query @spandex/react
 ```
 :::
 

--- a/site/docs/snippets/params/config.mdx
+++ b/site/docs/snippets/params/config.mdx
@@ -99,6 +99,12 @@ Swap fee for the integrator (in basis points). Only applicable if the provider s
 
 Surplus share for the integrator (in basis points). Only applicable if the provider supports surplus sharing.
 
+#### options.integratorFeeFn
+`((params: SwapParams) => FeeSettings | null | undefined | Promise<FeeSettings | null | undefined>) | undefined`
+
+Dynamic fee selector invoked once per swap request. Use this instead of static fee options when
+fee address, fee bps, surplus bps, or fee-token preference depend on the swap parameters.
+
 Fee and surplus settings are optimistic: providers that do not support the requested features may
 still return quotes, and selection will prefer quotes with more activated fee features before
 applying the secondary strategy (best price, lowest gas, etc).

--- a/site/package.json
+++ b/site/package.json
@@ -9,15 +9,17 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
+    "@tanstack/react-query": "^5.90.17",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "viem": "^2.40.1",
     "vocs": "^1.4.1",
     "@types/react": "^19.2.0",
     "@spandex/core": "workspace:*",
     "@spandex/react": "workspace:*",
     "tailwindcss": "^4.1.18",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3",
+    "wagmi": "^3.3.2"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -3,9 +3,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["node"],
 
     "allowJs": true,
 

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     dark: "/logo-dark.svg",
   },
   description: "DEX meta-aggregator library for optimal token swaps",
+  twoslash: false,
   ogImageUrl: {
     "/": "https://spandex.sh/og.jpg",
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "moduleDetection": "force",
+    "types": ["bun", "node"],
 
     "allowJs": false,
     "checkJs": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "include": ["packages/**/*.ts"]
 }


### PR DESCRIPTION
## Changes

* update to ts6 and adjust tsconfigs
* change viem to a peer dep, adjust docs. closes #122 (thanks @gskril)
* add dynamic fee resolution for integration fees via `(swap) -> fee` hook.
* add api key option for relay


## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change does not impact released packages (tests,docs,examples) (no release).