### PR TITLE
add o1 provider adapter

### DIFF
--- a/.changeset/o1-adapter.md
+++ b/.changeset/o1-adapter.md
@@ -1,0 +1,5 @@
+---
+"@spandex/core": minor
+---
+
+Add o1 provider adapter support.

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -17,11 +17,14 @@ Create an `.env` file in `examples/react` with:
 ```
 VITE_WALLET_CONNECT_PROJECT_ID=...
 VITE_BASE_RPC_URLS=...
+O1_BASE_URL=...
+O1_API_KEY=...
 ```
-Both variables are optional.
+All variables are optional.
 
 `VITE_WALLET_CONNECT_PROJECT_ID` is optional. If omitted, WalletConnect will be disabled.
 `VITE_BASE_RPC_URLS` is optional and accepts a comma-separated list of HTTPS RPC endpoints. If omitted, falls back to `http()`.
+`O1_BASE_URL` and `O1_API_KEY` enable the o1 provider on the server-side quote proxy route.
 
 All `VITE_*` variables are public and readable from the client, so do not include any secrets.
 

--- a/examples/react/src/components/IntentCapture/Insights/BumpChart.tsx
+++ b/examples/react/src/components/IntentCapture/Insights/BumpChart.tsx
@@ -24,6 +24,7 @@ export const COLORS: Record<string, string> = {
   odos: "var(--color-fabric-pink)",
   kyberswap: "var(--color-fabric-green)",
   nordstern: "var(--color-fabric-light-blue)",
+  o1: "var(--color-fabric-yellow)",
   fallback: "#ddd",
   secondary: "var(--color-border)",
   tertiary: "var(--color-outline)",

--- a/examples/react/src/components/IntentCapture/Insights/Tooltips/shared.tsx
+++ b/examples/react/src/components/IntentCapture/Insights/Tooltips/shared.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "../../../Skeleton";
 import { Tooltip } from "../../../Tooltip";
 import { COLORS } from "../BumpChart";
 
-export const PROVIDERS = ["fabric", "0x", "odos", "kyberswap", "nordstern"] as const;
+export const PROVIDERS = ["fabric", "0x", "odos", "kyberswap", "nordstern", "o1"] as const;
 
 export type BaseRow = { provider: string; color: string };
 

--- a/examples/react/src/routes/api/quoteProxy.ts
+++ b/examples/react/src/routes/api/quoteProxy.ts
@@ -1,22 +1,16 @@
-import {
-  createConfig,
-  fabric,
-  kyberswap,
-  nordstern,
-  odos,
-  type SwapParams,
-  zeroX,
-} from "@spandex/core";
+import { createConfig, defaultProviders, o1, zeroX, type SwapParams } from "@spandex/core";
 import { createPublicClient } from "viem";
 import { z } from "zod";
 import { configuredChains } from "@/config/onchain";
 
 export const proxyConfig = createConfig({
   providers: [
-    odos({}),
-    kyberswap({ clientId: "spandex_ui" }),
-    nordstern({}),
-    fabric({ appId: "spandex_ui" }),
+    ...defaultProviders({
+      appId: "spandex_ui",
+    }),
+    process.env.O1_BASE_URL && process.env.O1_API_KEY
+      ? o1({ baseUrl: process.env.O1_BASE_URL, apiKey: process.env.O1_API_KEY })
+      : undefined,
     process.env.ZEROX_API_KEY ? zeroX({ apiKey: process.env.ZEROX_API_KEY }) : undefined,
   ].filter((p): p is NonNullable<typeof p> => Boolean(p)),
   options: {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3,6 +3,7 @@ import { FabricAggregator, fabric } from "./lib/aggregators/fabric.js";
 import { KyberAggregator, kyberswap } from "./lib/aggregators/kyber.js";
 import { LifiAggregator, lifi } from "./lib/aggregators/lifi.js";
 import { NordsternAggregator, nordstern } from "./lib/aggregators/nordstern.js";
+import { O1Aggregator, o1 } from "./lib/aggregators/o1.js";
 import { OdosAggregator, odos } from "./lib/aggregators/odos.js";
 import { RelayAggregator, relay } from "./lib/aggregators/relay.js";
 import { VeloraAggregator, velora } from "./lib/aggregators/velora.js";
@@ -40,7 +41,9 @@ export {
   lifi,
   NordsternAggregator,
   nordstern,
+  O1Aggregator,
   OdosAggregator,
+  o1,
   odos,
   RelayAggregator,
   relay,

--- a/packages/core/lib/aggregators/o1.test.ts
+++ b/packages/core/lib/aggregators/o1.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import { defaultSwapParams } from "../../test/utils.js";
+import { O1Aggregator, type O1QuoteResponse, o1, o1RouteGraph } from "./o1.js";
+
+const ROUTER = "0x1111111111111111111111111111111111111111";
+const POOL = "0x2222222222222222222222222222222222222222";
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+type FetchMock = (input: FetchInput, init?: FetchInit) => ReturnType<typeof fetch>;
+
+function installFetchMock(mock: FetchMock) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = Object.assign(mock, {
+    preconnect: originalFetch.preconnect,
+  });
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+describe("o1", () => {
+  it("provides metadata", () => {
+    const aggregator = new O1Aggregator({
+      baseUrl: "https://api.o1.test",
+      apiKey: "test",
+    });
+    expect(aggregator.name()).toBe("o1");
+    expect(aggregator.features()).toEqual(["exactIn"]);
+    const metadata = aggregator.metadata();
+    expect(metadata.name).toBe("o1");
+    expect(metadata.url).toMatch(/o1/);
+    expect(metadata.docsUrl).toBe("https://docs.o1.exchange/api/dex-aggregator");
+  });
+
+  it("posts an execute request and normalizes the response", async () => {
+    let requestedUrl: string | undefined;
+    let requestedBody: unknown;
+    let requestedHeaders: Headers | undefined;
+
+    const restoreFetch = installFetchMock(async (input, init) => {
+      requestedUrl =
+        typeof input === "string" || input instanceof URL ? input.toString() : input.url;
+      requestedBody = JSON.parse(init?.body as string);
+      requestedHeaders = new Headers(init?.headers);
+
+      return new Response(JSON.stringify(mockO1Response()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    try {
+      const quote = await o1({
+        baseUrl: "https://api.o1.test/",
+        apiKey: "test-key",
+      }).fetchQuote(defaultSwapParams);
+
+      expect(requestedUrl).toBe("https://api.o1.test/execute");
+      expect(requestedHeaders?.get("x-api-key")).toBe("test-key");
+      expect(requestedBody).toEqual({
+        chainId: 8453,
+        tokenIn: defaultSwapParams.inputToken,
+        tokenOut: defaultSwapParams.outputToken,
+        amountIn: "500000000",
+        slippageBps: 100,
+        user: defaultSwapParams.swapperAccount,
+        useNativeIn: false,
+        unwrapNativeOut: false,
+      });
+
+      expect(quote.provider).toBe("o1");
+      if (!quote.success || quote.provider !== "o1") {
+        throw new Error("Expected successful o1 quote");
+      }
+      expect(quote.inputAmount).toBe(500_000_000n);
+      expect(quote.outputAmount).toBe(123_456_789n);
+      expect(quote.networkFee).toBe(1_000n);
+      expect(quote.txData.to).toBe(ROUTER);
+      expect(quote.txData.data).toBe("0x1234");
+      expect(quote.txData.gas).toBe(210_000n);
+      expect(quote.approval).toEqual({
+        token: defaultSwapParams.inputToken,
+        spender: ROUTER,
+      });
+      expect(quote.route?.nodes.length).toBe(2);
+      expect(quote.route?.edges[0]?.address).toBe(POOL);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("does not call the API outside the default Base support", async () => {
+    let called = false;
+    const restoreFetch = installFetchMock(async () => {
+      called = true;
+      return new Response("{}");
+    });
+
+    try {
+      const quote = await o1({
+        baseUrl: "https://api.o1.test",
+        apiKey: "test-key",
+      }).fetchQuote({ ...defaultSwapParams, chainId: 42161 }, { numRetries: 0 });
+
+      expect(quote.success).toBe(false);
+      expect(quote.provider).toBe("o1");
+      expect(called).toBe(false);
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it("does not support exact output quotes", async () => {
+    const quote = await o1({
+      baseUrl: "https://api.o1.test",
+      apiKey: "test-key",
+    }).fetchQuote(
+      {
+        chainId: 8453,
+        inputToken: defaultSwapParams.inputToken,
+        outputToken: defaultSwapParams.outputToken,
+        outputAmount: 10n ** 17n,
+        slippageBps: 100,
+        swapperAccount: defaultSwapParams.swapperAccount,
+        mode: "targetOut",
+      },
+      { numRetries: 0 },
+    );
+
+    expect(quote.success).toBe(false);
+    expect(quote.provider).toBe("o1");
+  });
+
+  it("rejects separate recipient accounts", async () => {
+    const quote = await o1({
+      baseUrl: "https://api.o1.test",
+      apiKey: "test-key",
+    }).fetchQuote(
+      {
+        ...defaultSwapParams,
+        recipientAccount: "0x0000000000000000000000000000000000000001",
+      },
+      { numRetries: 0 },
+    );
+
+    expect(quote.success).toBe(false);
+    expect(quote.provider).toBe("o1");
+  });
+
+  it("builds a route DAG", () => {
+    const dag = o1RouteGraph(mockO1Response());
+    expect(dag.nodes.length).toBe(2);
+    expect(dag.edges.length).toBe(1);
+    expect(dag.edges[0]?.source).toBe(defaultSwapParams.inputToken);
+    expect(dag.edges[0]?.target).toBe(defaultSwapParams.outputToken);
+    expect(dag.edges[0]?.key).toBe("pool-1");
+  });
+});
+
+function mockO1Response(): O1QuoteResponse {
+  return {
+    quoteId: "quote-1",
+    chainId: 8453,
+    to: ROUTER,
+    data: "0x1234",
+    value: "0",
+    expiresAt: Date.now() + 30_000,
+    routePlan: {
+      chainId: 8453,
+      tokenIn: defaultSwapParams.inputToken,
+      tokenOut: defaultSwapParams.outputToken,
+      amountIn: "500000000",
+      expectedAmountOut: "123456789",
+      minAmountOut: "122000000",
+      slippageBps: 100,
+      blockNumber: 1,
+      gasEstimate: {
+        gasUnits: 210000,
+        gasCostWei: "1000",
+      },
+      routes: [
+        {
+          amountIn: "500000000",
+          legs: [
+            {
+              dex: "UNIV3",
+              tokenIn: defaultSwapParams.inputToken,
+              tokenOut: defaultSwapParams.outputToken,
+              amountIn: "500000000",
+              minOut: "122000000",
+              poolId: "pool-1",
+              data: {
+                kind: "v3_direct",
+                pool: POOL,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/packages/core/lib/aggregators/o1.ts
+++ b/packages/core/lib/aggregators/o1.ts
@@ -1,0 +1,357 @@
+import { type Address, type Hex, zeroAddress } from "viem";
+import {
+  type AggregatorFeature,
+  type AggregatorMetadata,
+  type ExactInSwapParams,
+  type PoolEdge,
+  type ProviderConfig,
+  type ProviderKey,
+  QuoteError,
+  type RouteGraph,
+  type SuccessfulQuote,
+  type SwapOptions,
+  type SwapParams,
+  type TokenNode,
+  type TokenPricing,
+} from "../types.js";
+import { isNativeToken } from "../util/helpers.js";
+import { Aggregator } from "./index.js";
+
+const O1_DOCS_URL = "https://docs.o1.exchange/api/dex-aggregator";
+const DEFAULT_SUPPORTED_CHAINS = [8453];
+
+/**
+ * Configuration options for the o1 aggregator.
+ */
+export type O1Config = ProviderConfig & {
+  /**
+   * Base URL for the o1 API.
+   */
+  baseUrl: string;
+  /**
+   * API key sent as the `x-api-key` header.
+   */
+  apiKey: string;
+  /**
+   * Chain IDs this o1 deployment should be queried for.
+   * Defaults to Base (8453), matching the public o1 DEX Aggregator API.
+   */
+  supportedChains?: number[];
+};
+
+/**
+ * Aggregator implementation for the o1 DEX aggregator API.
+ *
+ * o1 exposes `POST /execute` as a one-shot quote and transaction assembly
+ * endpoint. spanDEX uses that endpoint because provider quotes must include
+ * executable calldata.
+ *
+ * @see https://docs.o1.exchange/api/dex-aggregator
+ */
+export class O1Aggregator extends Aggregator<O1Config> {
+  /**
+   * @inheritdoc
+   */
+  override metadata(): AggregatorMetadata {
+    return {
+      name: "o1",
+      url: "https://o1.exchange",
+      docsUrl: O1_DOCS_URL,
+    };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  override name(): ProviderKey {
+    return "o1";
+  }
+
+  /**
+   * o1 accepts either the zero address or the EIP-7528 sentinel for native
+   * tokens. spanDEX normalizes native assets to the zero address.
+   */
+  override nativeTokenAddress(): Address {
+    return zeroAddress;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  override features(): AggregatorFeature[] {
+    return ["exactIn"];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected override async tryFetchQuote(
+    request: SwapParams,
+    options: SwapOptions,
+  ): Promise<SuccessfulQuote> {
+    if (request.mode === "targetOut") {
+      throw new QuoteError("o1 aggregator does not support exact output quotes");
+    }
+
+    if ((request.outputChainId ?? request.chainId) !== request.chainId) {
+      throw new QuoteError("o1 aggregator does not support cross-chain quotes");
+    }
+
+    if (!this.supportedChains().includes(request.chainId)) {
+      throw new QuoteError(`o1 aggregator does not support chain ${request.chainId}`);
+    }
+
+    const recipient = request.recipientAccount ?? request.swapperAccount;
+    if (recipient.toLowerCase() !== request.swapperAccount.toLowerCase()) {
+      throw new QuoteError("o1 aggregator does not support separate recipient accounts");
+    }
+
+    const response = await this.execute(request as ExactInSwapParams, options);
+    const inputAmount = parseBigInt(response.routePlan.amountIn) ?? request.inputAmount;
+    const outputAmount = parseBigInt(response.routePlan.expectedAmountOut) ?? 0n;
+    const networkFee = parseBigInt(response.routePlan.gasEstimate?.gasCostWei) ?? 0n;
+    const txValue = parseBigInt(response.value) ?? 0n;
+    const gas = gasLimit(response.routePlan.gasEstimate?.gasUnits);
+
+    return {
+      success: true,
+      provider: "o1",
+      details: response,
+      latency: 0,
+      inputChainId: request.chainId,
+      outputChainId: request.chainId,
+      execution: "atomic",
+      inputAmount,
+      outputAmount,
+      networkFee,
+      txData: {
+        to: response.to,
+        data: response.data,
+        ...(txValue > 0n ? { value: txValue } : {}),
+        ...(gas !== undefined ? { gas } : {}),
+      },
+      approval: !isNativeToken(request.inputToken)
+        ? {
+            token: request.inputToken,
+            spender: response.to,
+          }
+        : undefined,
+      route: o1RouteGraph(response),
+      pricing: buildO1Pricing(request as ExactInSwapParams),
+    };
+  }
+
+  private async execute(
+    request: ExactInSwapParams,
+    options: SwapOptions,
+  ): Promise<O1QuoteResponse> {
+    if (!this.config.baseUrl) {
+      throw new Error(
+        "o1 API base URL is not set. Please set the O1_BASE_URL environment variable.",
+      );
+    }
+    if (!this.config.apiKey) {
+      throw new Error("o1 API key is not set. Please set the O1_API_KEY environment variable.");
+    }
+
+    const response = await fetch(`${this.baseUrl()}/execute`, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        "x-api-key": this.config.apiKey,
+      },
+      body: JSON.stringify(extractBodyParams(request, options, this.supportsFeature.bind(this))),
+    });
+
+    const body = await response.json().catch(() => undefined);
+    if (!response.ok) {
+      throw new QuoteError(`o1 API request failed with status ${response.status}`, body);
+    }
+
+    return body as O1QuoteResponse;
+  }
+
+  private baseUrl() {
+    return this.config.baseUrl.replace(/\/$/, "");
+  }
+
+  private supportedChains(): number[] {
+    return this.config.supportedChains ?? DEFAULT_SUPPORTED_CHAINS;
+  }
+}
+
+/**
+ * Convenience factory for creating an o1 aggregator instance.
+ *
+ * @param config - o1 configuration.
+ * @returns O1Aggregator instance.
+ */
+export function o1(config: O1Config): O1Aggregator {
+  return new O1Aggregator(config);
+}
+
+function extractBodyParams(
+  params: ExactInSwapParams,
+  options: SwapOptions,
+  supportsFeature: (feature: AggregatorFeature) => boolean,
+): O1ExecuteRequest {
+  const body: O1ExecuteRequest = {
+    chainId: params.chainId,
+    tokenIn: params.inputToken,
+    tokenOut: params.outputToken,
+    amountIn: params.inputAmount.toString(),
+    slippageBps: params.slippageBps,
+    user: params.swapperAccount,
+    useNativeIn: isNativeToken(params.inputToken),
+    unwrapNativeOut: isNativeToken(params.outputToken),
+  };
+
+  if (options.integratorSwapFeeBps !== undefined && supportsFeature("integratorFees")) {
+    body.feeBps = options.integratorSwapFeeBps;
+  }
+
+  return body;
+}
+
+export function o1RouteGraph(response: O1QuoteResponse): RouteGraph {
+  const nodeMap = new Map<string, TokenNode>();
+  const setNode = (address: Address) => {
+    nodeMap.set(address.toLowerCase(), { address });
+  };
+
+  setNode(response.routePlan.tokenIn);
+  setNode(response.routePlan.tokenOut);
+
+  const edges: PoolEdge[] = [];
+  for (const [routeIndex, route] of response.routePlan.routes.entries()) {
+    for (const [legIndex, leg] of route.legs.entries()) {
+      setNode(leg.tokenIn);
+      setNode(leg.tokenOut);
+      edges.push({
+        source: leg.tokenIn,
+        target: leg.tokenOut,
+        address: legAddress(leg),
+        key: leg.poolId ?? `${leg.dex}-${routeIndex}-${legIndex}`,
+        value: Number(leg.amountIn),
+      });
+    }
+  }
+
+  return {
+    nodes: [...nodeMap.values()],
+    edges,
+  };
+}
+
+function legAddress(leg: O1RouteLeg): Address | undefined {
+  const data = leg.data;
+  if (isAddressLike(data?.pool)) {
+    return data.pool;
+  }
+  if (isAddressLike(data?.router)) {
+    return data.router;
+  }
+  return undefined;
+}
+
+function isAddressLike(value: unknown): value is Address {
+  return typeof value === "string" && /^0x[a-fA-F0-9]{40}$/.test(value);
+}
+
+function buildO1Pricing(request: ExactInSwapParams): {
+  inputToken: TokenPricing;
+  outputToken: TokenPricing;
+} {
+  return {
+    inputToken: { address: request.inputToken },
+    outputToken: { address: request.outputToken },
+  };
+}
+
+function parseBigInt(value?: string | number | bigint): bigint | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  try {
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function gasLimit(gasUnits?: number): bigint | undefined {
+  if (!Number.isFinite(gasUnits)) {
+    return undefined;
+  }
+  return BigInt(Math.trunc(gasUnits as number));
+}
+
+type O1ExecuteRequest = {
+  chainId: number;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: string;
+  slippageBps: number;
+  user: Address;
+  feeBps?: number;
+  useNativeIn: boolean;
+  unwrapNativeOut: boolean;
+};
+
+type O1LegData = {
+  pool?: Address;
+  router?: Address;
+  [key: string]: unknown;
+};
+
+export type O1QuoteResponse = {
+  quoteId: string;
+  chainId: number;
+  to: Address;
+  data: Hex;
+  value: string;
+  routePlan: {
+    chainId: number;
+    tokenIn: Address;
+    tokenOut: Address;
+    amountIn: string;
+    expectedAmountOut: string;
+    minAmountOut: string;
+    feeBps?: number;
+    slippageBps: number;
+    routes: O1SplitRoute[];
+    blockNumber: number;
+    gasEstimate?: {
+      gasUnits?: number;
+      gasCostWei?: string;
+    };
+    nativeIn?: boolean;
+    nativeOut?: boolean;
+    providerCalldata?: {
+      source: string;
+      to: Address;
+      data: Hex;
+      value: string;
+      gas?: number;
+    };
+  };
+  expiresAt: number;
+  provider?: string;
+  simWarning?: string;
+};
+
+type O1SplitRoute = {
+  amountIn: string;
+  legs: O1RouteLeg[];
+};
+
+type O1RouteLeg = {
+  dex: string;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: string;
+  minOut: string;
+  poolId?: string;
+  data?: O1LegData;
+};

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -5,6 +5,7 @@ import type { Aggregator } from "./aggregators/index.js";
 import type { KyberConfig, KyberQuoteResponse } from "./aggregators/kyber.js";
 import type { LifiConfig, LifiQuoteResponse } from "./aggregators/lifi.js";
 import type { NordsternConfig, NordsternQuoteResponse } from "./aggregators/nordstern.js";
+import type { O1Config, O1QuoteResponse } from "./aggregators/o1.js";
 import type { OdosConfig, OdosQuoteResponse } from "./aggregators/odos.js";
 import type { RelayConfig, RelayQuoteResponse } from "./aggregators/relay.js";
 import type { VeloraConfig, VeloraQuoteResponse } from "./aggregators/velora.js";
@@ -33,6 +34,10 @@ export type ProviderDefinitions = {
   nordstern: {
     config: NordsternConfig;
     quote: NordsternQuoteResponse;
+  };
+  o1: {
+    config: O1Config;
+    quote: O1QuoteResponse;
   };
   odos: {
     config: OdosConfig;

--- a/site/docs/components/logo/o1.tsx
+++ b/site/docs/components/logo/o1.tsx
@@ -1,0 +1,3 @@
+export function O1Logo() {
+  return <img src="/o1-logo.svg" alt="o1" className="h-[26px] w-auto" height={26} width={26} />;
+}

--- a/site/docs/pages/configuration/providers.mdx
+++ b/site/docs/pages/configuration/providers.mdx
@@ -4,6 +4,7 @@ import { FabricLogo } from "../../components/logo/fabric";
 import { KyberSwapLogo } from "../../components/logo/kyberswap";
 import { LifiLogo } from "../../components/logo/lifi";
 import { NordsternLogo } from "../../components/logo/nordstern";
+import { O1Logo } from "../../components/logo/o1";
 import { OdosLogo } from "../../components/logo/odos";
 import { RelayLogo } from "../../components/logo/relay";
 import { VeloraLogo } from "../../components/logo/velora";
@@ -36,6 +37,10 @@ under real load. No single aggregator wins every trade or delivers 100% uptime.
   <a className="provider-card" href="/providers/nordstern">
     <span className="provider-card__logo"><NordsternLogo /></span>
     <span className="provider-card__name">Nordstern</span>
+  </a>
+  <a className="provider-card" href="/providers/o1">
+    <span className="provider-card__logo"><O1Logo /></span>
+    <span className="provider-card__name">o1</span>
   </a>
   <a className="provider-card" href="/providers/lifi">
     <span className="provider-card__logo"><LifiLogo /></span>

--- a/site/docs/pages/core/functions/createConfig.mdx
+++ b/site/docs/pages/core/functions/createConfig.mdx
@@ -5,11 +5,15 @@ import ConfigParams from '../../../snippets/params/config.mdx'
 Create a configuration object to customize providers and options for all aggregation functions.
 
 ```ts
-import { createConfig, fabric, kyberswap, nordstern, odos, zeroX } from "@spandex/core";
+import { createConfig, fabric, kyberswap, nordstern, o1, odos, zeroX } from "@spandex/core";
 
 export const config = createConfig({
   providers: [
     zeroX({ apiKey: "YOUR_0X_API_KEY" }),
+    o1({
+      baseUrl: "https://api.example.com",
+      apiKey: "YOUR_O1_API_KEY",
+    }),
     fabric({ appId: "YOUR_FABRIC_APP_ID" }),
     nordstern({}),
     odos({}),

--- a/site/docs/pages/providers/o1.mdx
+++ b/site/docs/pages/providers/o1.mdx
@@ -1,0 +1,46 @@
+import { Button } from 'vocs/components'
+import { Callout } from 'vocs/components'
+
+# o1
+
+<div className="flex flex-row gap-4">
+  <Button href="https://o1.exchange">Homepage</Button>
+  <Button href="https://docs.o1.exchange/api/dex-aggregator">Docs</Button>
+</div>
+
+## Configuration
+
+<Callout type="info">
+  o1 supports `exactIn` quotes through its `/execute` endpoint. It does not
+  support exact-output or cross-chain quotes in spanDEX.
+</Callout>
+
+```ts twoslash
+import { createConfig, o1 } from "@spandex/core";
+
+export const config = createConfig({
+  providers: [
+    o1({
+      baseUrl: "https://api.example.com",
+      apiKey: "YOUR_O1_API_KEY",
+      // Optional. Defaults to Base.
+      supportedChains: [8453],
+    }),
+    // ...
+  ],
+});
+```
+
+## Notes
+
+- The adapter defaults to Base (`8453`), matching the public o1 DEX Aggregator
+  API. Override `supportedChains` only if your o1 deployment has different chain
+  coverage.
+- spanDEX calls o1's `/execute` endpoint so returned quotes include
+  broadcast-ready calldata.
+- o1 uses one `user` value for the transaction sender and recipient. Quotes
+  with a separate `recipientAccount` are rejected by the adapter.
+- The adapter does not advertise integrator fee support by default because
+  o1 accepts `feeBps` but not a per-request fee recipient. Only enable
+  `negotiatedFeatures: ["integratorFees"]` for deployments with fee recipient
+  handling configured server-side.

--- a/site/docs/public/o1-logo.svg
+++ b/site/docs/public/o1-logo.svg
@@ -1,0 +1,20 @@
+<svg width="306" height="306" viewBox="0 0 306 306" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4684_13)">
+<rect width="306" height="306" fill="#1A1A1A"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M145 122C147.761 122 150 124.239 150 127V147C150 149.761 152.239 152 155 152H175C177.761 152 180 154.239 180 157V237C180 239.761 177.761 242 175 242H95C92.239 242 90 239.761 90 237V217C90 214.239 87.761 212 85 212H65C62.239 212 60 209.761 60 207V127C60 124.239 62.239 122 65 122H145ZM95 152C92.239 152 90 154.239 90 157V207C90 209.761 92.239 212 95 212H145C147.761 212 150 209.761 150 207V157C150 154.239 147.761 152 145 152H95Z" fill="url(#paint0_linear_4684_13)"/>
+<path d="M235 62C237.761 62 240 64.239 240 67V207C240 209.761 237.761 212 235 212H215C212.239 212 210 209.761 210 207V127C210 124.239 207.761 122 205 122H185C182.239 122 180 119.761 180 117V97C180 94.239 182.239 92 185 92H205C207.761 92 210 89.761 210 87V67C210 64.239 212.239 62 215 62H235Z" fill="url(#paint1_linear_4684_13)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_4684_13" x1="239.722" y1="151.709" x2="60.278" y2="151.709" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9CD6FF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint1_linear_4684_13" x1="239.722" y1="151.709" x2="60.278" y2="151.709" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9CD6FF"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<clipPath id="clip0_4684_13">
+<rect width="306" height="306" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/site/docs/snippets/params/config.mdx
+++ b/site/docs/snippets/params/config.mdx
@@ -15,6 +15,7 @@ provider to test alternate configurations.
 | `kyberswap` | no | [View](/providers/kyberswap) |
 | `odos` | no | [View](/providers/odos) |
 | `nordstern` | no | [View](/providers/nordstern) |
+| `o1` | yes | [View](/providers/o1) |
 | `lifi` | no | [View](/providers/lifi) |
 | `relay` | no | [View](/providers/relay) |
 | `velora` | no | [View](/providers/velora) |

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -212,6 +212,10 @@ export default defineConfig({
           link: "/providers/nordstern",
         },
         {
+          text: "o1",
+          link: "/providers/o1",
+        },
+        {
           text: "Relay",
           link: "/providers/relay",
         },


### PR DESCRIPTION
Adds o1 DEX aggregator support to spanDEX core and wires it into the React QuoteBench example as an optional provider.

Changes:
- Added the `o1` core adapter using the public o1 `/execute` API with `x-api-key` authentication.
- Exported the `o1` factory and provider types through `@spandex/core`.
- Added adapter tests for request payloads, quote normalization, unsupported modes and chains, recipient validation, and route graph generation.
- Updated the React quote proxy to enable o1 when `O1_BASE_URL` and `O1_API_KEY` are configured.
- Added o1 to the QuoteBench provider UI colors/tooltips.
- Added o1 provider documentation, sidebar/provider list entries, logo asset, and a changeset.

Testing:
- `bun test packages/core/lib/aggregators/o1.test.ts packages/core/lib/createConfig.test.ts`
- `bunx tsc --ignoreConfig --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types bun --strict packages/core/lib/aggregators/o1.test.ts`
- `bun ./scripts/build-packages.ts core`
- `git diff --check`