### PR TITLE
feat(react): consume `buildCalls` in examples/react, extend PublicClient

### DIFF
--- a/.changeset/olive-camels-search.md
+++ b/.changeset/olive-camels-search.md
@@ -1,0 +1,5 @@
+---
+"@spandex/react": patch
+---
+
+Fix `SpandexProvider` handing core a bare wagmi `Client` cast as `PublicClient`. Clients are now extended with viem `publicActions`, so core code paths that call client methods directly (e.g. the allowance check in `buildCalls` during quote execution) work instead of throwing `client.<method> is not a function`.

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 #misc
 .scratch
 .npmrc
+.zed/settings.json

--- a/bun.lock
+++ b/bun.lock
@@ -1797,7 +1797,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shiki": ["shiki@1.29.2", "", { "dependencies": { "@shikijs/core": "1.29.2", "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/langs": "1.29.2", "@shikijs/themes": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
-        "@types/bun": "^1.3.13",
-        "@types/node": "^25.6.1",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^25.9.1",
         "typescript": "6.0.3",
       },
     },

--- a/examples/react/src/components/IntentCapture/index.tsx
+++ b/examples/react/src/components/IntentCapture/index.tsx
@@ -1,7 +1,14 @@
-import type { SimulatedQuote } from "@spandex/core";
-import { useQuotes } from "@spandex/react";
+import {
+  buildCalls,
+  type SimulationFailure,
+  type SuccessfulQuote,
+  type SuccessfulSimulatedQuote,
+  type SwapParams,
+} from "@spandex/core";
+import { useQuotes, useSpandexConfig } from "@spandex/react";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
-import { type Address, encodeFunctionData, erc20Abi, type Hex, maxUint256 } from "viem";
+import type { Address, Hex } from "viem";
 import { useConnection } from "wagmi";
 import { getExplorerLink } from "@/config/onchain";
 import { useAllowance } from "@/hooks/useAllowance";
@@ -35,61 +42,10 @@ export type TxData = {
   gas?: bigint;
 };
 
-function prepareCalls({
-  chainId,
-  bestQuote,
-  needsApproval,
-  sellTokenAddress,
-}: {
-  chainId?: number;
-  bestQuote?: SimulatedQuote;
-  needsApproval: boolean;
-  sellTokenAddress: Address;
-}): TxData[] {
-  if (!chainId || !bestQuote?.success) return [];
-
-  const calls: TxData[] = [];
-
-  if (bestQuote.txData.data) {
-    const spender = bestQuote.txData.to;
-
-    if (needsApproval) {
-      const approvalData = encodeFunctionData({
-        abi: erc20Abi,
-        functionName: "approve",
-        args: [spender, maxUint256],
-      });
-
-      calls.push({
-        to: sellTokenAddress,
-        name: "APPROVE",
-        data: approvalData,
-        chainId,
-        value: 0n,
-      });
-    }
-
-    const swapCall: TxData = {
-      to: bestQuote.txData.to,
-      name: "SELL",
-      data: bestQuote.txData.data,
-      chainId,
-      value: BigInt(bestQuote.txData.value || 0),
-    };
-
-    // specify gasLimit with 50% buffer using the simulated `gasUsed`.
-    // if the `gasUsed` is indeed undefined, we can fall back to the wallet's gas estimation.
-    if (bestQuote.simulation.success) {
-      const { gasUsed } = bestQuote.simulation;
-      const gasLimit = gasUsed ? (gasUsed * 150n) / 100n : undefined;
-      swapCall.gas = gasLimit;
-    }
-
-    calls.push(swapCall);
-  }
-
-  return calls;
-}
+// a quote that returned successfully but whose simulation reverted; narrowing
+// FailedSimulatedQuote (an intersection containing the Quote union) through
+// `success` checks is unreliable across TS versions, so name the shape directly
+type FailedSimulationQuote = SuccessfulQuote & { simulation: SimulationFailure };
 
 const QUOTE_REFRESH_INTERVAL_MS = 10_000;
 
@@ -97,6 +53,7 @@ export function IntentCapture() {
   const { sellToken, setSellToken, buyToken, setBuyToken, onSuccessfulTx } = useTokenSelect();
   const { address, chainId, isConnected } = useConnection();
   const { isSupportedChain } = useSupportedChain();
+  const spandexConfig = useSpandexConfig();
   const [prevSellToken, setPrevSellToken] = useState(sellToken);
   const [numSellTokens, setNumSellTokens] = useState<string>(sellToken.defaultInput);
   const [selectedMetric, setSelectedMetric] = useState<Metric>("price");
@@ -176,22 +133,23 @@ export function IntentCapture() {
     metric: selectedMetric,
   });
 
+  // when nothing is executable, surface a quote whose simulation reverted to explain why
+  const failedSimQuote = !bestQuote
+    ? quotes?.find((q): q is FailedSimulationQuote => q.success && !q.simulation.success)
+    : undefined;
+
+  // allowance is only read to explain simulation failures; approvals are
+  // built by buildCalls below
+  const allowanceQuote = bestQuote ?? failedSimQuote;
   const { data: allowance } = useAllowance({
     chainId: sellToken.chainId,
     owner: address,
     token: sellToken.address,
-    spender: bestQuote?.success ? bestQuote.txData.to : undefined,
+    spender: allowanceQuote
+      ? (allowanceQuote.approval?.spender ?? allowanceQuote.txData.to)
+      : undefined,
     enabled: isSupportedChain,
   });
-
-  const needsApproval = useMemo(() => {
-    if (!bestQuote?.success) return false;
-
-    const inputAmount = BigInt(bestQuote.inputAmount || 0);
-    const currentAllowance = allowance || 0n;
-
-    return inputAmount > 0n && currentAllowance < inputAmount;
-  }, [bestQuote, allowance]);
 
   // derive all swap errors
   const errors: SwapErrorState = useMemo(() => {
@@ -231,7 +189,7 @@ export function IntentCapture() {
       });
     }
 
-    if (quotes?.length && !bestQuote) {
+    if (quotes?.length && !bestQuote && !failedSimQuote) {
       state.quote.push({
         title: "No valid quotes available",
         description: "All aggregators failed to return a quote",
@@ -239,13 +197,13 @@ export function IntentCapture() {
       });
     }
 
-    if (bestQuote?.success && !bestQuote.simulation.success) {
-      const reason = getSimulationFailureReason(bestQuote, allowance);
+    if (failedSimQuote) {
+      const reason = getSimulationFailureReason(failedSimQuote, allowance);
       state.simulation.push({
         title: reason || "Simulation failed",
         description: "This swap will likely fail if executed",
-        details: bestQuote.simulation.error?.message,
-        cause: bestQuote.simulation,
+        details: failedSimQuote.simulation.error.message,
+        cause: failedSimQuote.simulation,
       });
     }
 
@@ -264,6 +222,7 @@ export function IntentCapture() {
     quotes,
     quotesQueryError,
     bestQuote,
+    failedSimQuote,
     allowance,
     txError,
   ]);
@@ -272,15 +231,37 @@ export function IntentCapture() {
     errors.input.length || errors.quote.length || errors.simulation.length,
   );
 
-  const calls = useMemo(
-    () =>
-      prepareCalls({
-        chainId: sellToken.chainId,
-        bestQuote,
-        needsApproval,
-        sellTokenAddress: sellToken.address,
+  // build approval + swap calls with core's buildCalls: it checks the onchain
+  // allowance, encodes the approval when needed, and applies simulated gas buffers
+  const { data: builtCalls } = useQuery({
+    queryKey: [
+      "spandex",
+      "buildCalls",
+      bestQuote?.provider ?? null,
+      bestQuote?.txData.to ?? null,
+      bestQuote?.txData.data ?? null,
+      swap.chainId,
+      swap.swapperAccount,
+      swap.inputAmount.toString(),
+    ],
+    queryFn: () =>
+      buildCalls({
+        quote: bestQuote as SuccessfulSimulatedQuote,
+        swap: swap as SwapParams,
+        config: spandexConfig,
+        allowanceMode: "unlimited",
       }),
-    [bestQuote, needsApproval, sellToken],
+    enabled: Boolean(bestQuote),
+  });
+
+  const calls: TxData[] = useMemo(
+    () =>
+      (builtCalls ?? []).map((call) => ({
+        ...call.txn,
+        name: call.type === "approval" ? "APPROVE" : "SELL",
+        chainId: swap.chainId,
+      })),
+    [builtCalls, swap.chainId],
   );
 
   const onSwitchTokens = useCallback(() => {

--- a/examples/react/src/config/onchain.ts
+++ b/examples/react/src/config/onchain.ts
@@ -9,17 +9,23 @@ type ChainConfig = {
   executorBlockNumber?: bigint; // Optional block number for the executor
 };
 
+const customBaseRpcUrl = import.meta.env.VITE_BASE_RPC_URL;
+
 export const configuredChains: ChainConfig[] = [
   {
     chain: base,
-    transport: fallback([
-      http("https://base.drpc.org", {
-        batch: true,
-      }),
-      http("https://1rpc.io/base", {
-        batch: true,
-      }),
-    ]),
+    transport: fallback(
+      [
+        // public RPC's rate limit; option for our own paid RPC url
+        customBaseRpcUrl ? http(customBaseRpcUrl, { batch: true }) : undefined,
+        http("https://base.drpc.org", {
+          batch: true,
+        }),
+        http("https://1rpc.io/base", {
+          batch: true,
+        }),
+      ].filter((t) => t !== undefined),
+    ),
   },
 ];
 

--- a/examples/react/src/utils/quoteHelpers.ts
+++ b/examples/react/src/utils/quoteHelpers.ts
@@ -49,7 +49,7 @@ export function getBestQuoteByMetric({
 }: {
   quotes?: SimulatedQuote[];
   metric: Metric;
-}): SimulatedQuote | undefined {
+}): SuccessfulSimulatedQuote | undefined {
   if (!quotes || quotes.length === 0) return undefined;
 
   const successfulQuotes = quotes.filter(

--- a/packages/react/lib/context/SpandexProvider.test.tsx
+++ b/packages/react/lib/context/SpandexProvider.test.tsx
@@ -15,6 +15,12 @@ function TestComponent() {
   return <div>MetaAggregator: {config ? "exists" : "missing"}</div>;
 }
 
+function ClientProbe({ chainId }: { chainId: number }) {
+  const config = useSpandexConfig();
+  const client = config.clientLookup(chainId);
+  return <div>readContract: {typeof client?.readContract === "function" ? "yes" : "no"}</div>;
+}
+
 describe("SpandexProvider", () => {
   it("should provide metaAggregator to children", () => {
     render(<TestComponent />, {
@@ -24,5 +30,18 @@ describe("SpandexProvider", () => {
     });
 
     expect(screen.getByText("MetaAggregator: exists")).toBeDefined();
+  });
+
+  // wagmi's getClient returns a bare viem Client; the provider must extend it
+  // with publicActions or core's method-style calls (e.g. readContract in
+  // buildCalls) throw at execution time
+  it("should provide public clients with decorated actions", () => {
+    render(<ClientProbe chainId={8453} />, {
+      spandexConfig: {
+        providers: [fabric({ appId: "test" })],
+      },
+    });
+
+    expect(screen.getByText("readContract: yes")).toBeDefined();
   });
 });

--- a/packages/react/lib/context/SpandexProvider.tsx
+++ b/packages/react/lib/context/SpandexProvider.tsx
@@ -1,6 +1,6 @@
 import { createConfig } from "@spandex/core";
 import { createContext, useContext, useMemo } from "react";
-import type { PublicClient } from "viem";
+import { type PublicClient, publicActions } from "viem";
 import { useConfig } from "wagmi";
 import type { SpandexContextValue, SpandexProviderProps } from "../types.js";
 
@@ -12,7 +12,10 @@ export function SpandexProvider({ config, children }: SpandexProviderProps) {
   const spandexConfig = useMemo(() => {
     return createConfig({
       ...config,
-      clients: (chainId: number) => getClient({ chainId }) as PublicClient | undefined,
+      // wagmi's getClient returns a bare viem Client; core expects a
+      // PublicClient with decorated actions (e.g. readContract in buildCalls)
+      clients: (chainId: number) =>
+        getClient({ chainId })?.extend(publicActions) as PublicClient | undefined,
     });
   }, [config, getClient]);
 


### PR DESCRIPTION
Fixes a runtime bug in `SpandexProvider` and dogfoods core's `buildCalls` in the example app.

While prototyping quote execution in the react example app, clicking swap threw `client.readContract is not a function`. Wagmi's `getClient` returns a bare viem `Client` with no decorated actions; we were casting it to `PublicClient` and handing it to core. Simulation never caught this because `simulateQuote` invokes actions function-style; `buildCalls` calls `client.readContract` directly and throws in the client.

## Changes

- `SpandexProvider` extends wagmi clients with `publicActions` (same as wagmi's own `getPublicClient`) + regression test + patch changeset
- react example app: hand-rolled `prepareCalls` -> core's `buildCalls`. Approvals now target `quote.approval.spender` instead of assuming `txData.to`, gas buffer is core's default 33% instead of our previous 50%.
- react example app: simulation failure errors (insufficient allowance, etc) actually render now; the old branch was unreachable since `getBestQuoteByMetric` never returns failed sims
- react example app: `VITE_BASE_RPC_URL` for local dev (public Base RPCs throttle concurrent `eth_simulateV1`)

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change does not impact released packages (tests,docs,examples) (no release).