### PR TITLE
feat(react): add useExecuteQuote hook

### DIFF
--- a/.changeset/thin-radios-share.md
+++ b/.changeset/thin-radios-share.md
@@ -1,0 +1,5 @@
+---
+"@spandex/react": minor
+---
+
+Add a `useExecuteQuote` mutation hook for executing selected quotes with Wagmi-backed wallet and public clients.

--- a/examples/react/src/hooks/useWalletProperties.ts
+++ b/examples/react/src/hooks/useWalletProperties.ts
@@ -32,7 +32,7 @@ export function useWalletProperties({ chainId }: { chainId: number }) {
     // biome-ignore lint/suspicious/noExplicitAny: <>
     const chainCapabilities: any = capabilities[chainId];
     if (chainCapabilities) {
-      result.batching = chainCapabilities?.atomic?.status === "supported";
+      result.batching = isAtomicBatchReady(chainCapabilities?.atomic?.status);
       result.paymasterSupport = chainCapabilities?.paymasterService?.supported === true;
     }
 
@@ -45,4 +45,8 @@ export function useWalletProperties({ chainId }: { chainId: number }) {
 function isInjected(connector?: Connector): boolean {
   // TODO: What else can we do here?
   return connector?.type === "injected" || connector?.type === "metaMask";
+}
+
+function isAtomicBatchReady(status?: string): boolean {
+  return status === "supported" || status === "ready";
 }

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,4 +1,5 @@
 export { SpandexProvider, useSpandexConfig } from "./lib/context/SpandexProvider.js";
+export { useExecuteQuote } from "./lib/hooks/useExecuteQuote.js";
 export { useQuote } from "./lib/hooks/useQuote.js";
 export { useQuotes } from "./lib/hooks/useQuotes.js";
 export type { SpandexContextValue, SpandexProviderProps } from "./lib/types.js";

--- a/packages/react/lib/hooks/useExecuteQuote.test.tsx
+++ b/packages/react/lib/hooks/useExecuteQuote.test.tsx
@@ -18,6 +18,9 @@ let mockBuildCalls: ReturnType<typeof mock>;
 let mockGetCapabilities: ReturnType<typeof mock>;
 let mockSendTransactionSync: ReturnType<typeof mock>;
 let mockSendCallsSync: ReturnType<typeof mock>;
+let mockCapabilitiesData:
+  | { atomic?: { status: "supported" | "ready" | "unsupported" } }
+  | undefined;
 
 const defaultSwap = {
   mode: "exactIn" as const,
@@ -54,6 +57,16 @@ function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
       outputAmount: 1_000_000n,
       priceDelta: 0,
       accuracy: 0,
+    },
+  } as SuccessfulSimulatedQuote;
+}
+
+function createMockQuoteWithTxData(data: string): SuccessfulSimulatedQuote {
+  return {
+    ...createMockSimulatedQuote(),
+    txData: {
+      ...createMockQuote().txData,
+      data,
     },
   } as SuccessfulSimulatedQuote;
 }
@@ -102,6 +115,9 @@ function setupWagmi({
     useConnection: () => ({
       address: resolvedAddress,
       chain: resolvedChainId ? { id: resolvedChainId } : undefined,
+    }),
+    useCapabilities: () => ({
+      data: mockCapabilitiesData,
     }),
     useWalletClient: () => ({
       data: hasWalletClient
@@ -167,6 +183,11 @@ describe("useExecuteQuote", () => {
         receipts: [{ transactionHash: transactionHashes.batch }],
       }),
     );
+    mockCapabilitiesData = {
+      atomic: {
+        status: "unsupported",
+      },
+    };
 
     mock.module("@spandex/core", () => ({
       buildCalls: mockBuildCalls,
@@ -329,9 +350,11 @@ describe("useExecuteQuote", () => {
   });
 
   it("batches approval and swap when atomic execution is supported", async () => {
-    mockGetCapabilities.mockImplementation(() =>
-      Promise.resolve({ atomic: { status: "supported" } }),
-    );
+    mockCapabilitiesData = {
+      atomic: {
+        status: "supported",
+      },
+    };
     mockBuildCalls.mockImplementation(() =>
       Promise.resolve([
         createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
@@ -363,6 +386,28 @@ describe("useExecuteQuote", () => {
         action: "Approve & Swap",
         completed: true,
       });
+    });
+  });
+
+  it("treats atomic ready as batch-capable", async () => {
+    mockCapabilitiesData = {
+      atomic: {
+        status: "ready",
+      },
+    };
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
+        createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" }),
+      ]),
+    );
+
+    const { result } = renderUseExecuteQuote();
+
+    await waitFor(() => {
+      expect(result.current.mode).toBe("batched");
+      expect(result.current.canAutoExecute).toBe(true);
+      expect(result.current.currentActionLabel).toBe("Approve & Swap");
     });
   });
 
@@ -429,6 +474,67 @@ describe("useExecuteQuote", () => {
         action: "Swap",
         completed: true,
       });
+    });
+  });
+
+  it("keeps stepped progress when a new quote arrives between clicks", async () => {
+    mockBuildCalls.mockImplementation(({ quote }: { quote: SuccessfulSimulatedQuote }) =>
+      Promise.resolve([
+        createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
+        createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: quote.txData.data }),
+      ]),
+    );
+
+    const firstQuote = createMockQuoteWithTxData("0xswap1");
+    const secondQuote = createMockQuoteWithTxData("0xswap2");
+
+    const { result, rerender } = renderHook(
+      ({ quote }: { quote: SuccessfulSimulatedQuote }) =>
+        useExecuteQuote({
+          swap: createSwap(),
+          quote,
+        }),
+      {
+        initialProps: {
+          quote: firstQuote,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.mode).toBe("stepped");
+      expect(result.current.currentActionLabel).toBe("Approve");
+      expect(result.current.currentStepIndex).toBe(1);
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentActionLabel).toBe("Swap");
+      expect(result.current.currentStepIndex).toBe(2);
+      expect(result.current.steps[0]?.hash).toBe(transactionHashes.approval);
+    });
+
+    await act(async () => {
+      rerender({ quote: secondQuote });
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentActionLabel).toBe("Swap");
+      expect(result.current.currentStepIndex).toBe(2);
+      expect(result.current.steps[0]?.hash).toBe(transactionHashes.approval);
+      expect(result.current.steps[1]?.status).toBe("active");
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(mockSendTransactionSync).toHaveBeenCalledTimes(2);
+      expect(mockSendTransactionSync.mock.calls[1]?.[0]?.data).toBe("0xswap1");
     });
   });
 

--- a/packages/react/lib/hooks/useExecuteQuote.test.tsx
+++ b/packages/react/lib/hooks/useExecuteQuote.test.tsx
@@ -2,16 +2,17 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { SuccessfulSimulatedQuote } from "@spandex/core";
 import { act } from "@testing-library/react";
 import { createPublicClient, http, type PublicClient } from "viem";
-import { base, mainnet } from "viem/chains";
+import { base } from "viem/chains";
 import { TEST_ADDRESSES, TEST_CHAINS } from "../../test/constants.js";
 import { createMockQuote } from "../../test/mocks.js";
 import { renderHook, waitFor } from "../../test/utils.js";
 import { useExecuteQuote } from "./useExecuteQuote.js";
 
-const walletClient = {
-  account: TEST_ADDRESSES.alice,
-  chain: { id: TEST_CHAINS.base.id },
-} as const;
+const transactionHashes = {
+  approval: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
+  swap: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as const,
+  batch: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" as const,
+};
 
 function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
   return {
@@ -38,18 +39,28 @@ function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
 }
 
 describe("useExecuteQuote", () => {
-  let mockExecuteQuote: ReturnType<typeof mock>;
+  let mockBuildCalls: ReturnType<typeof mock>;
+  let mockGetCapabilities: ReturnType<typeof mock>;
+  let mockSendTransactionSync: ReturnType<typeof mock>;
+  let mockSendCallsSync: ReturnType<typeof mock>;
 
   beforeEach(() => {
-    mockExecuteQuote = mock(() =>
+    mockBuildCalls = mock();
+    mockGetCapabilities = mock(() => Promise.resolve({ atomic: { status: "unsupported" } }));
+    mockSendTransactionSync = mock(({ data }: { data: string }) =>
       Promise.resolve({
-        transactionHash:
-          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
+        transactionHash: data === "0xapprove" ? transactionHashes.approval : transactionHashes.swap,
+      }),
+    );
+    mockSendCallsSync = mock(() =>
+      Promise.resolve({
+        status: "success",
+        receipts: [{ transactionHash: transactionHashes.batch }],
       }),
     );
 
     mock.module("@spandex/core", () => ({
-      executeQuote: mockExecuteQuote,
+      buildCalls: mockBuildCalls,
     }));
 
     mock.module("wagmi", () => ({
@@ -58,7 +69,13 @@ describe("useExecuteQuote", () => {
         chain: { id: TEST_CHAINS.base.id },
       }),
       useWalletClient: () => ({
-        data: walletClient,
+        data: {
+          account: TEST_ADDRESSES.alice,
+          chain: { id: TEST_CHAINS.base.id },
+          getCapabilities: mockGetCapabilities,
+          sendTransactionSync: mockSendTransactionSync,
+          sendCallsSync: mockSendCallsSync,
+        },
       }),
       useConfig: () => ({
         getClient: ({ chainId }: { chainId: number }) => {
@@ -69,25 +86,25 @@ describe("useExecuteQuote", () => {
             }) as PublicClient;
           }
 
-          if (chainId === TEST_CHAINS.mainnet.id) {
-            return createPublicClient({
-              chain: mainnet,
-              transport: http("https://eth.drpc.org"),
-            }) as PublicClient;
-          }
-
           return undefined;
         },
       }),
     }));
   });
 
-  it("should merge wagmi connection data with params and execute the quote", async () => {
+  it("prepares and executes a single-call route", async () => {
     const quote = createMockSimulatedQuote();
-    const { result } = renderHook(() => useExecuteQuote());
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        {
+          type: "swap",
+          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
+        },
+      ]),
+    );
 
-    await act(async () => {
-      await result.current.executeQuoteAsync({
+    const { result } = renderHook(() =>
+      useExecuteQuote({
         swap: {
           mode: "exactIn",
           inputToken: TEST_ADDRESSES.usdc,
@@ -96,88 +113,178 @@ describe("useExecuteQuote", () => {
           slippageBps: 100,
         },
         quote,
-      });
-    });
-
-    await waitFor(() => {
-      expect(mockExecuteQuote).toHaveBeenCalledWith(
-        expect.objectContaining({
-          quote,
-          walletClient,
-          allowanceMode: "exact",
-          swap: {
-            mode: "exactIn",
-            chainId: TEST_CHAINS.base.id,
-            inputToken: TEST_ADDRESSES.usdc,
-            outputToken: TEST_ADDRESSES.weth,
-            inputAmount: 500_000_000n,
-            slippageBps: 100,
-            swapperAccount: TEST_ADDRESSES.alice,
-            outputChainId: undefined,
-            recipientAccount: undefined,
-          },
-        }),
-      );
-
-      expect(mockExecuteQuote.mock.calls[0]?.[0]?.publicClient?.chain?.id).toBe(
-        TEST_CHAINS.base.id,
-      );
-      expect(result.current.data).toEqual({
-        transactionHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      });
-    });
-  });
-
-  it("should allow per-call allowanceMode and swap overrides", async () => {
-    const quote = createMockSimulatedQuote();
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        allowanceMode: "exact",
       }),
     );
 
+    await waitFor(() => {
+      expect(result.current.mode).toBe("single");
+      expect(result.current.currentActionLabel).toBe("Swap");
+      expect(result.current.totalSteps).toBe(1);
+      expect(result.current.canAutoExecute).toBe(true);
+      expect(result.current.steps[0]?.status).toBe("active");
+    });
+
     await act(async () => {
-      await result.current.executeQuoteAsync({
-        swap: {
-          mode: "targetOut",
-          chainId: TEST_CHAINS.mainnet.id,
-          swapperAccount: TEST_ADDRESSES.bob,
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          outputAmount: 1_000_000n,
-          slippageBps: 75,
-          recipientAccount: TEST_ADDRESSES.alice,
-        },
-        quote,
-        allowanceMode: "unlimited",
-      });
+      await result.current.executeQuoteAsync();
     });
 
     await waitFor(() => {
-      expect(mockExecuteQuote).toHaveBeenCalledWith(
-        expect.objectContaining({
-          allowanceMode: "unlimited",
-          swap: {
-            mode: "targetOut",
-            chainId: TEST_CHAINS.mainnet.id,
-            swapperAccount: TEST_ADDRESSES.bob,
-            inputToken: TEST_ADDRESSES.usdc,
-            outputToken: TEST_ADDRESSES.weth,
-            outputAmount: 1_000_000n,
-            slippageBps: 75,
-            outputChainId: undefined,
-            recipientAccount: TEST_ADDRESSES.alice,
-          },
-        }),
-      );
-
-      expect(mockExecuteQuote.mock.calls[0]?.[0]?.publicClient?.chain?.id).toBe(
-        TEST_CHAINS.mainnet.id,
-      );
+      expect(mockBuildCalls).toHaveBeenCalled();
+      expect(mockSendTransactionSync).toHaveBeenCalledTimes(1);
+      expect(mockSendCallsSync).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual({
+        transactionHash: transactionHashes.swap,
+        mode: "single",
+        stepIndex: 1,
+        totalSteps: 1,
+        action: "Swap",
+        completed: true,
+      });
+      expect(result.current.steps[0]?.status).toBe("complete");
     });
   });
 
-  it("should surface a clear error when chainId and swapperAccount cannot be resolved", async () => {
+  it("batches approval and swap when atomic execution is supported", async () => {
+    const quote = createMockSimulatedQuote();
+    mockGetCapabilities.mockImplementation(() =>
+      Promise.resolve({ atomic: { status: "supported" } }),
+    );
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        {
+          type: "approval",
+          txn: { to: TEST_ADDRESSES.usdc, data: "0xapprove", chainId: TEST_CHAINS.base.id },
+        },
+        {
+          type: "swap",
+          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.mode).toBe("batched");
+      expect(result.current.currentActionLabel).toBe("Approve & Swap");
+      expect(result.current.canAutoExecute).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(mockSendCallsSync).toHaveBeenCalledTimes(1);
+      expect(mockSendTransactionSync).not.toHaveBeenCalled();
+      expect(result.current.steps.every((step) => step.status === "complete")).toBe(true);
+      expect(result.current.data).toEqual({
+        transactionHash: transactionHashes.batch,
+        mode: "batched",
+        stepIndex: 2,
+        totalSteps: 2,
+        action: "Approve & Swap",
+        completed: true,
+      });
+    });
+  });
+
+  it("steps through approval and swap when batching is unavailable", async () => {
+    const quote = createMockSimulatedQuote();
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        {
+          type: "approval",
+          txn: { to: TEST_ADDRESSES.usdc, data: "0xapprove", chainId: TEST_CHAINS.base.id },
+        },
+        {
+          type: "swap",
+          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.mode).toBe("stepped");
+      expect(result.current.currentActionLabel).toBe("Approve");
+      expect(result.current.currentStepIndex).toBe(1);
+      expect(result.current.currentStepText).toBe("Step 1 of 2");
+      expect(result.current.canAutoExecute).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(mockSendTransactionSync).toHaveBeenCalledTimes(1);
+      expect(result.current.steps[0]).toMatchObject({
+        status: "complete",
+        hash: transactionHashes.approval,
+      });
+      expect(result.current.steps[1]?.status).toBe("active");
+      expect(result.current.currentActionLabel).toBe("Swap");
+      expect(result.current.currentStepIndex).toBe(2);
+      expect(result.current.currentStepText).toBe("Step 2 of 2");
+      expect(result.current.data).toEqual({
+        transactionHash: transactionHashes.approval,
+        mode: "stepped",
+        stepIndex: 1,
+        totalSteps: 2,
+        action: "Approve",
+        completed: false,
+      });
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(mockSendTransactionSync).toHaveBeenCalledTimes(2);
+      expect(result.current.steps[1]).toMatchObject({
+        status: "complete",
+        hash: transactionHashes.swap,
+      });
+      expect(result.current.currentActionLabel).toBeNull();
+      expect(result.current.currentStepIndex).toBeNull();
+      expect(result.current.currentStepText).toBeNull();
+      expect(result.current.data).toEqual({
+        transactionHash: transactionHashes.swap,
+        mode: "stepped",
+        stepIndex: 2,
+        totalSteps: 2,
+        action: "Swap",
+        completed: true,
+      });
+    });
+  });
+
+  it("surfaces a clear preparation error when chainId and swapperAccount cannot be resolved", async () => {
     mock.module("wagmi", () => ({
       useConnection: () => ({
         address: undefined,
@@ -192,27 +299,28 @@ describe("useExecuteQuote", () => {
     }));
 
     const quote = createMockSimulatedQuote();
-    const { result } = renderHook(() => useExecuteQuote());
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+      }),
+    );
 
-    await act(async () => {
-      await expect(
-        result.current.executeQuoteAsync({
-          swap: {
-            mode: "exactIn",
-            inputToken: TEST_ADDRESSES.usdc,
-            outputToken: TEST_ADDRESSES.weth,
-            inputAmount: 500_000_000n,
-            slippageBps: 100,
-          },
-          quote,
-        }),
-      ).rejects.toThrow("No chainId provided to useExecuteQuote");
+    await waitFor(() => {
+      expect(result.current.preparationError?.message).toBe(
+        "No chainId provided to useExecuteQuote. Pass swap.chainId or connect a wallet on the target chain.",
+      );
     });
 
-    expect(mockExecuteQuote).not.toHaveBeenCalled();
-    await waitFor(() => {
-      expect(result.current.error?.message).toBe(
-        "No chainId provided to useExecuteQuote. Pass swap.chainId or connect a wallet on the target chain.",
+    await act(async () => {
+      await expect(result.current.executeQuoteAsync()).rejects.toThrow(
+        "No chainId provided to useExecuteQuote",
       );
     });
   });

--- a/packages/react/lib/hooks/useExecuteQuote.test.tsx
+++ b/packages/react/lib/hooks/useExecuteQuote.test.tsx
@@ -144,6 +144,95 @@ describe("useExecuteQuote", () => {
     });
   });
 
+  it("rebuilds the execution plan when a per-call allowance override changes it", async () => {
+    const quote = createMockSimulatedQuote();
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        {
+          type: "swap",
+          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+        allowanceMode: "exact",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockBuildCalls).toHaveBeenCalledTimes(1);
+      expect(mockBuildCalls.mock.calls[0]?.[0]?.allowanceMode).toBe("exact");
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync({ allowanceMode: "unlimited" });
+    });
+
+    await waitFor(() => {
+      expect(mockBuildCalls).toHaveBeenCalledTimes(2);
+      expect(mockBuildCalls.mock.calls[1]?.[0]?.allowanceMode).toBe("unlimited");
+    });
+  });
+
+  it("does not prepare calls until enabled when preparation is disabled", async () => {
+    const quote = createMockSimulatedQuote();
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        {
+          type: "swap",
+          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+        preparation: {
+          enabled: false,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(false);
+      expect(mockBuildCalls).not.toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(mockBuildCalls).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual({
+        transactionHash: transactionHashes.swap,
+        mode: "single",
+        stepIndex: 1,
+        totalSteps: 1,
+        action: "Swap",
+        completed: true,
+      });
+    });
+  });
+
   it("batches approval and swap when atomic execution is supported", async () => {
     const quote = createMockSimulatedQuote();
     mockGetCapabilities.mockImplementation(() =>

--- a/packages/react/lib/hooks/useExecuteQuote.test.tsx
+++ b/packages/react/lib/hooks/useExecuteQuote.test.tsx
@@ -14,6 +14,26 @@ const transactionHashes = {
   batch: "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" as const,
 };
 
+let mockBuildCalls: ReturnType<typeof mock>;
+let mockGetCapabilities: ReturnType<typeof mock>;
+let mockSendTransactionSync: ReturnType<typeof mock>;
+let mockSendCallsSync: ReturnType<typeof mock>;
+
+const defaultSwap = {
+  mode: "exactIn" as const,
+  inputToken: TEST_ADDRESSES.usdc,
+  outputToken: TEST_ADDRESSES.weth,
+  inputAmount: 500_000_000n,
+  slippageBps: 100,
+};
+
+type TestSwap = typeof defaultSwap & {
+  chainId?: number;
+  outputChainId?: number;
+  swapperAccount?: `0x${string}`;
+  recipientAccount?: `0x${string}`;
+};
+
 function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
   return {
     ...createMockQuote(),
@@ -38,12 +58,101 @@ function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
   } as SuccessfulSimulatedQuote;
 }
 
-describe("useExecuteQuote", () => {
-  let mockBuildCalls: ReturnType<typeof mock>;
-  let mockGetCapabilities: ReturnType<typeof mock>;
-  let mockSendTransactionSync: ReturnType<typeof mock>;
-  let mockSendCallsSync: ReturnType<typeof mock>;
+function createSwap(overrides: Partial<TestSwap> = {}): TestSwap {
+  return {
+    ...defaultSwap,
+    ...overrides,
+  };
+}
 
+function createBuiltCall({
+  type,
+  data,
+  to,
+}: {
+  type: "approval" | "swap";
+  data: string;
+  to: `0x${string}`;
+}) {
+  return {
+    type,
+    txn: {
+      to,
+      data,
+      chainId: TEST_CHAINS.base.id,
+    },
+  };
+}
+
+function setupWagmi({
+  address = TEST_ADDRESSES.alice,
+  chainId = TEST_CHAINS.base.id,
+  hasWalletClient = true,
+  hasPublicClient = true,
+}: {
+  address?: `0x${string}` | null;
+  chainId?: number | null;
+  hasWalletClient?: boolean;
+  hasPublicClient?: boolean;
+} = {}) {
+  const resolvedAddress = address ?? undefined;
+  const resolvedChainId = chainId ?? undefined;
+
+  mock.module("wagmi", () => ({
+    useConnection: () => ({
+      address: resolvedAddress,
+      chain: resolvedChainId ? { id: resolvedChainId } : undefined,
+    }),
+    useWalletClient: () => ({
+      data: hasWalletClient
+        ? {
+            account: resolvedAddress,
+            chain: resolvedChainId ? { id: resolvedChainId } : undefined,
+            getCapabilities: mockGetCapabilities,
+            sendTransactionSync: mockSendTransactionSync,
+            sendCallsSync: mockSendCallsSync,
+            uid: "test-wallet-client",
+          }
+        : undefined,
+    }),
+    useConfig: () => ({
+      getClient: ({ chainId: requestedChainId }: { chainId: number }) => {
+        if (hasPublicClient && requestedChainId === TEST_CHAINS.base.id) {
+          return createPublicClient({
+            chain: base,
+            transport: http("https://base.drpc.org"),
+          }) as PublicClient;
+        }
+
+        return undefined;
+      },
+    }),
+  }));
+}
+
+function renderUseExecuteQuote({
+  swap,
+  quote = createMockSimulatedQuote(),
+  ...params
+}: {
+  swap?: Partial<TestSwap>;
+  quote?: SuccessfulSimulatedQuote;
+  allowanceMode?: "exact" | "unlimited";
+  preparation?: { enabled?: boolean };
+} = {}) {
+  return {
+    quote,
+    ...renderHook(() =>
+      useExecuteQuote({
+        swap: createSwap(swap),
+        quote,
+        ...params,
+      }),
+    ),
+  };
+}
+
+describe("useExecuteQuote", () => {
   beforeEach(() => {
     mockBuildCalls = mock();
     mockGetCapabilities = mock(() => Promise.resolve({ atomic: { status: "unsupported" } }));
@@ -62,59 +171,15 @@ describe("useExecuteQuote", () => {
     mock.module("@spandex/core", () => ({
       buildCalls: mockBuildCalls,
     }));
-
-    mock.module("wagmi", () => ({
-      useConnection: () => ({
-        address: TEST_ADDRESSES.alice,
-        chain: { id: TEST_CHAINS.base.id },
-      }),
-      useWalletClient: () => ({
-        data: {
-          account: TEST_ADDRESSES.alice,
-          chain: { id: TEST_CHAINS.base.id },
-          getCapabilities: mockGetCapabilities,
-          sendTransactionSync: mockSendTransactionSync,
-          sendCallsSync: mockSendCallsSync,
-        },
-      }),
-      useConfig: () => ({
-        getClient: ({ chainId }: { chainId: number }) => {
-          if (chainId === TEST_CHAINS.base.id) {
-            return createPublicClient({
-              chain: base,
-              transport: http("https://base.drpc.org"),
-            }) as PublicClient;
-          }
-
-          return undefined;
-        },
-      }),
-    }));
+    setupWagmi();
   });
 
   it("prepares and executes a single-call route", async () => {
-    const quote = createMockSimulatedQuote();
     mockBuildCalls.mockImplementation(() =>
-      Promise.resolve([
-        {
-          type: "swap",
-          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
-        },
-      ]),
+      Promise.resolve([createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" })]),
     );
 
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-      }),
-    );
+    const { result } = renderUseExecuteQuote();
 
     await waitFor(() => {
       expect(result.current.mode).toBe("single");
@@ -145,29 +210,11 @@ describe("useExecuteQuote", () => {
   });
 
   it("rebuilds the execution plan when a per-call allowance override changes it", async () => {
-    const quote = createMockSimulatedQuote();
     mockBuildCalls.mockImplementation(() =>
-      Promise.resolve([
-        {
-          type: "swap",
-          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
-        },
-      ]),
+      Promise.resolve([createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" })]),
     );
 
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-        allowanceMode: "exact",
-      }),
-    );
+    const { result } = renderUseExecuteQuote({ allowanceMode: "exact" });
 
     await waitFor(() => {
       expect(mockBuildCalls).toHaveBeenCalledTimes(1);
@@ -185,31 +232,15 @@ describe("useExecuteQuote", () => {
   });
 
   it("does not prepare calls until enabled when preparation is disabled", async () => {
-    const quote = createMockSimulatedQuote();
     mockBuildCalls.mockImplementation(() =>
-      Promise.resolve([
-        {
-          type: "swap",
-          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
-        },
-      ]),
+      Promise.resolve([createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" })]),
     );
 
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-        preparation: {
-          enabled: false,
-        },
-      }),
-    );
+    const { result } = renderUseExecuteQuote({
+      preparation: {
+        enabled: false,
+      },
+    });
 
     await waitFor(() => {
       expect(result.current.isReady).toBe(false);
@@ -233,36 +264,82 @@ describe("useExecuteQuote", () => {
     });
   });
 
+  it("surfaces stepped UI state after on-demand plan building", async () => {
+    mockBuildCalls.mockImplementation(() =>
+      Promise.resolve([
+        createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
+        createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" }),
+      ]),
+    );
+
+    const { result } = renderUseExecuteQuote({
+      preparation: {
+        enabled: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.mode).toBeNull();
+      expect(result.current.steps).toHaveLength(0);
+      expect(mockBuildCalls).not.toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await result.current.executeQuoteAsync();
+    });
+
+    await waitFor(() => {
+      expect(result.current.mode).toBe("stepped");
+      expect(result.current.currentActionLabel).toBe("Swap");
+      expect(result.current.currentStepIndex).toBe(2);
+      expect(result.current.currentStepText).toBe("Step 2 of 2");
+      expect(result.current.steps[0]).toMatchObject({
+        status: "complete",
+        hash: transactionHashes.approval,
+      });
+      expect(result.current.steps[1]?.status).toBe("active");
+    });
+  });
+
+  it("does not bypass wallet requirements when preparation.enabled is true", async () => {
+    setupWagmi({
+      address: null,
+      chainId: null,
+      hasWalletClient: false,
+      hasPublicClient: false,
+    });
+
+    const { result } = renderUseExecuteQuote({
+      swap: {
+        chainId: TEST_CHAINS.base.id,
+        swapperAccount: TEST_ADDRESSES.alice,
+      },
+      preparation: {
+        enabled: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.preparationError?.message).toBe(
+        "No WalletClient available from wagmi. Connect a wallet before executing.",
+      );
+      expect(result.current.isPreparing).toBe(false);
+      expect(mockBuildCalls).not.toHaveBeenCalled();
+    });
+  });
+
   it("batches approval and swap when atomic execution is supported", async () => {
-    const quote = createMockSimulatedQuote();
     mockGetCapabilities.mockImplementation(() =>
       Promise.resolve({ atomic: { status: "supported" } }),
     );
     mockBuildCalls.mockImplementation(() =>
       Promise.resolve([
-        {
-          type: "approval",
-          txn: { to: TEST_ADDRESSES.usdc, data: "0xapprove", chainId: TEST_CHAINS.base.id },
-        },
-        {
-          type: "swap",
-          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
-        },
+        createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
+        createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" }),
       ]),
     );
 
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-      }),
-    );
+    const { result } = renderUseExecuteQuote();
 
     await waitFor(() => {
       expect(result.current.mode).toBe("batched");
@@ -290,32 +367,14 @@ describe("useExecuteQuote", () => {
   });
 
   it("steps through approval and swap when batching is unavailable", async () => {
-    const quote = createMockSimulatedQuote();
     mockBuildCalls.mockImplementation(() =>
       Promise.resolve([
-        {
-          type: "approval",
-          txn: { to: TEST_ADDRESSES.usdc, data: "0xapprove", chainId: TEST_CHAINS.base.id },
-        },
-        {
-          type: "swap",
-          txn: { to: TEST_ADDRESSES.weth, data: "0xswap", chainId: TEST_CHAINS.base.id },
-        },
+        createBuiltCall({ type: "approval", to: TEST_ADDRESSES.usdc, data: "0xapprove" }),
+        createBuiltCall({ type: "swap", to: TEST_ADDRESSES.weth, data: "0xswap" }),
       ]),
     );
 
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-      }),
-    );
+    const { result } = renderUseExecuteQuote();
 
     await waitFor(() => {
       expect(result.current.mode).toBe("stepped");
@@ -374,32 +433,14 @@ describe("useExecuteQuote", () => {
   });
 
   it("surfaces a clear preparation error when chainId and swapperAccount cannot be resolved", async () => {
-    mock.module("wagmi", () => ({
-      useConnection: () => ({
-        address: undefined,
-        chain: undefined,
-      }),
-      useWalletClient: () => ({
-        data: undefined,
-      }),
-      useConfig: () => ({
-        getClient: () => undefined,
-      }),
-    }));
+    setupWagmi({
+      address: null,
+      chainId: null,
+      hasWalletClient: false,
+      hasPublicClient: false,
+    });
 
-    const quote = createMockSimulatedQuote();
-    const { result } = renderHook(() =>
-      useExecuteQuote({
-        swap: {
-          mode: "exactIn",
-          inputToken: TEST_ADDRESSES.usdc,
-          outputToken: TEST_ADDRESSES.weth,
-          inputAmount: 500_000_000n,
-          slippageBps: 100,
-        },
-        quote,
-      }),
-    );
+    const { result } = renderUseExecuteQuote();
 
     await waitFor(() => {
       expect(result.current.preparationError?.message).toBe(

--- a/packages/react/lib/hooks/useExecuteQuote.test.tsx
+++ b/packages/react/lib/hooks/useExecuteQuote.test.tsx
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { SuccessfulSimulatedQuote } from "@spandex/core";
+import { act } from "@testing-library/react";
+import { createPublicClient, http, type PublicClient } from "viem";
+import { base, mainnet } from "viem/chains";
+import { TEST_ADDRESSES, TEST_CHAINS } from "../../test/constants.js";
+import { createMockQuote } from "../../test/mocks.js";
+import { renderHook, waitFor } from "../../test/utils.js";
+import { useExecuteQuote } from "./useExecuteQuote.js";
+
+const walletClient = {
+  account: TEST_ADDRESSES.alice,
+  chain: { id: TEST_CHAINS.base.id },
+} as const;
+
+function createMockSimulatedQuote(): SuccessfulSimulatedQuote {
+  return {
+    ...createMockQuote(),
+    simulation: {
+      success: true,
+      outputAmount: 1_000_000n,
+      latency: 25,
+      gasUsed: 123_456n,
+      approvalGasUsed: 45_000n,
+      blockNumber: 123n,
+      swapResult: {
+        status: "success",
+      },
+    },
+    performance: {
+      latency: 25,
+      gasUsed: 123_456n,
+      outputAmount: 1_000_000n,
+      priceDelta: 0,
+      accuracy: 0,
+    },
+  } as SuccessfulSimulatedQuote;
+}
+
+describe("useExecuteQuote", () => {
+  let mockExecuteQuote: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    mockExecuteQuote = mock(() =>
+      Promise.resolve({
+        transactionHash:
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
+      }),
+    );
+
+    mock.module("@spandex/core", () => ({
+      executeQuote: mockExecuteQuote,
+    }));
+
+    mock.module("wagmi", () => ({
+      useConnection: () => ({
+        address: TEST_ADDRESSES.alice,
+        chain: { id: TEST_CHAINS.base.id },
+      }),
+      useWalletClient: () => ({
+        data: walletClient,
+      }),
+      useConfig: () => ({
+        getClient: ({ chainId }: { chainId: number }) => {
+          if (chainId === TEST_CHAINS.base.id) {
+            return createPublicClient({
+              chain: base,
+              transport: http("https://base.drpc.org"),
+            }) as PublicClient;
+          }
+
+          if (chainId === TEST_CHAINS.mainnet.id) {
+            return createPublicClient({
+              chain: mainnet,
+              transport: http("https://eth.drpc.org"),
+            }) as PublicClient;
+          }
+
+          return undefined;
+        },
+      }),
+    }));
+  });
+
+  it("should merge wagmi connection data with params and execute the quote", async () => {
+    const quote = createMockSimulatedQuote();
+    const { result } = renderHook(() => useExecuteQuote());
+
+    await act(async () => {
+      await result.current.executeQuoteAsync({
+        swap: {
+          mode: "exactIn",
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          inputAmount: 500_000_000n,
+          slippageBps: 100,
+        },
+        quote,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockExecuteQuote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          quote,
+          walletClient,
+          allowanceMode: "exact",
+          swap: {
+            mode: "exactIn",
+            chainId: TEST_CHAINS.base.id,
+            inputToken: TEST_ADDRESSES.usdc,
+            outputToken: TEST_ADDRESSES.weth,
+            inputAmount: 500_000_000n,
+            slippageBps: 100,
+            swapperAccount: TEST_ADDRESSES.alice,
+            outputChainId: undefined,
+            recipientAccount: undefined,
+          },
+        }),
+      );
+
+      expect(mockExecuteQuote.mock.calls[0]?.[0]?.publicClient?.chain?.id).toBe(
+        TEST_CHAINS.base.id,
+      );
+      expect(result.current.data).toEqual({
+        transactionHash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      });
+    });
+  });
+
+  it("should allow per-call allowanceMode and swap overrides", async () => {
+    const quote = createMockSimulatedQuote();
+    const { result } = renderHook(() =>
+      useExecuteQuote({
+        allowanceMode: "exact",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.executeQuoteAsync({
+        swap: {
+          mode: "targetOut",
+          chainId: TEST_CHAINS.mainnet.id,
+          swapperAccount: TEST_ADDRESSES.bob,
+          inputToken: TEST_ADDRESSES.usdc,
+          outputToken: TEST_ADDRESSES.weth,
+          outputAmount: 1_000_000n,
+          slippageBps: 75,
+          recipientAccount: TEST_ADDRESSES.alice,
+        },
+        quote,
+        allowanceMode: "unlimited",
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockExecuteQuote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowanceMode: "unlimited",
+          swap: {
+            mode: "targetOut",
+            chainId: TEST_CHAINS.mainnet.id,
+            swapperAccount: TEST_ADDRESSES.bob,
+            inputToken: TEST_ADDRESSES.usdc,
+            outputToken: TEST_ADDRESSES.weth,
+            outputAmount: 1_000_000n,
+            slippageBps: 75,
+            outputChainId: undefined,
+            recipientAccount: TEST_ADDRESSES.alice,
+          },
+        }),
+      );
+
+      expect(mockExecuteQuote.mock.calls[0]?.[0]?.publicClient?.chain?.id).toBe(
+        TEST_CHAINS.mainnet.id,
+      );
+    });
+  });
+
+  it("should surface a clear error when chainId and swapperAccount cannot be resolved", async () => {
+    mock.module("wagmi", () => ({
+      useConnection: () => ({
+        address: undefined,
+        chain: undefined,
+      }),
+      useWalletClient: () => ({
+        data: undefined,
+      }),
+      useConfig: () => ({
+        getClient: () => undefined,
+      }),
+    }));
+
+    const quote = createMockSimulatedQuote();
+    const { result } = renderHook(() => useExecuteQuote());
+
+    await act(async () => {
+      await expect(
+        result.current.executeQuoteAsync({
+          swap: {
+            mode: "exactIn",
+            inputToken: TEST_ADDRESSES.usdc,
+            outputToken: TEST_ADDRESSES.weth,
+            inputAmount: 500_000_000n,
+            slippageBps: 100,
+          },
+          quote,
+        }),
+      ).rejects.toThrow("No chainId provided to useExecuteQuote");
+    });
+
+    expect(mockExecuteQuote).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe(
+        "No chainId provided to useExecuteQuote. Pass swap.chainId or connect a wallet on the target chain.",
+      );
+    });
+  });
+});

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -13,9 +13,9 @@ import {
   useMutation,
   useQuery,
 } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { type Hash, type PublicClient, publicActions, type WalletClient } from "viem";
-import { useConfig, useConnection, useWalletClient } from "wagmi";
+import { useCapabilities, useConfig, useConnection, useWalletClient } from "wagmi";
 import { useSpandexConfig } from "../context/SpandexProvider.js";
 
 type UseSwapParams = (
@@ -120,6 +120,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
   const wagmiConfig = useConfig();
   const connection = useConnection();
   const { data: walletClient } = useWalletClient();
+  const [frozenQuote, setFrozenQuote] = useState<SuccessfulSimulatedQuote | null>(null);
   const [runtimePlan, setRuntimePlan] = useState<PreparedExecutionPlan | null>(null);
   const [progress, setProgress] = useState<StepProgress>({ completedCount: 0, hashes: {} });
 
@@ -147,10 +148,29 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
   }, [wagmiConfig, resolvedSwapResult.swap]);
 
   const defaultAllowanceMode = allowanceMode ?? "exact";
+  const activeQuote = frozenQuote ?? quote;
   const walletError =
     !walletClient && !resolvedSwapResult.error && resolvedSwapResult.swap
       ? new Error("No WalletClient available from wagmi. Connect a wallet before executing.")
       : null;
+  const { data: capabilities } = useCapabilities({
+    account: connection.address,
+    chainId: resolvedSwapResult.swap?.chainId,
+    query: {
+      enabled: Boolean(connection.address && resolvedSwapResult.swap?.chainId),
+    },
+  });
+
+  const canBatch = useMemo(() => {
+    if (!capabilities || !resolvedSwapResult.swap) return false;
+
+    return isAtomicBatchReady(
+      getAtomicCapabilityStatus({
+        capabilities,
+        chainId: resolvedSwapResult.swap.chainId,
+      }),
+    );
+  }, [capabilities, resolvedSwapResult.swap]);
 
   const progressKey = useMemo(() => {
     const resolvedSwap = resolvedSwapResult.swap;
@@ -168,11 +188,12 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       outputAmount:
         resolvedSwap?.mode === "targetOut" ? resolvedSwap.outputAmount.toString() : null,
       allowanceMode: defaultAllowanceMode,
-      provider: quote.provider,
-      quoteTo: quote.txData.to,
-      quoteData: quote.txData.data,
+      provider: activeQuote.provider,
+      quoteTo: activeQuote.txData.to,
+      quoteData: activeQuote.txData.data,
     });
-  }, [walletClient?.uid, resolvedSwapResult.swap, defaultAllowanceMode, quote]);
+  }, [walletClient?.uid, resolvedSwapResult.swap, defaultAllowanceMode, activeQuote]);
+  const lastResetKeyRef = useRef(progressKey);
 
   const isPreparationEnabled =
     Boolean(resolvedSwapResult.swap && walletClient) && (preparation?.enabled ?? true);
@@ -195,11 +216,11 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
 
       return buildPreparedExecutionPlan({
         config,
-        quote,
+        quote: activeQuote,
         swap: resolvedSwap,
-        walletClient: walletClient as WalletClient,
         publicClient,
         allowanceMode: defaultAllowanceMode,
+        canBatch,
       });
     },
     enabled: isPreparationEnabled,
@@ -239,13 +260,16 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
           ? preparedPlan.data
           : await buildPreparedExecutionPlan({
               config,
-              quote,
+              quote: activeQuote,
               swap: resolvedSwap,
-              walletClient: walletClient as WalletClient,
               publicClient,
               allowanceMode: executionAllowanceMode,
+              canBatch,
             });
 
+      if (plan.mode === "stepped") {
+        setFrozenQuote((current) => current ?? activeQuote);
+      }
       setRuntimePlan(plan);
 
       if (plan.mode === "batched") {
@@ -310,18 +334,26 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       });
 
       await mutation?.onSuccess?.(data, variables, context, mutationContext);
+
+      if (data.completed) {
+        setFrozenQuote(null);
+      }
     },
     onError: async (error, variables, context, mutationContext) => {
+      setFrozenQuote(null);
       await mutation?.onError?.(error, variables, context, mutationContext);
     },
   });
 
   useEffect(() => {
-    void progressKey;
+    if (lastResetKeyRef.current === progressKey) return;
+    if (frozenQuote) return;
+
+    lastResetKeyRef.current = progressKey;
     setRuntimePlan(null);
     setProgress({ completedCount: 0, hashes: {} });
     result.reset();
-  }, [progressKey, result.reset]);
+  }, [frozenQuote, progressKey, result.reset]);
 
   const activePlan = preparedPlan.data ?? runtimePlan;
   const totalSteps = activePlan?.calls.length ?? 0;
@@ -382,16 +414,16 @@ async function buildPreparedExecutionPlan({
   config,
   quote,
   swap,
-  walletClient,
   publicClient,
   allowanceMode,
+  canBatch,
 }: {
   config: ReturnType<typeof useSpandexConfig>;
   quote: SuccessfulSimulatedQuote;
   swap: ExactInSwapParams | TargetOutSwapParams;
-  walletClient: WalletClient;
   publicClient?: PublicClient;
   allowanceMode: AllowanceMode;
+  canBatch: boolean;
 }): Promise<PreparedExecutionPlan> {
   const calls = await buildCalls({
     config,
@@ -401,7 +433,6 @@ async function buildPreparedExecutionPlan({
     allowanceMode,
   });
 
-  const canBatch = await isBatchSupported(walletClient);
   return {
     mode: resolveExecutionMode({ calls, canBatch }),
     calls,
@@ -426,13 +457,25 @@ function resolveExecutionMode({
   return "stepped";
 }
 
-async function isBatchSupported(client: WalletClient): Promise<boolean> {
-  try {
-    const capabilities = await client.getCapabilities({ chainId: client.chain?.id || 0 });
-    return capabilities.atomic?.status === "supported";
-  } catch {
-    return false;
+function isAtomicBatchReady(status?: string): boolean {
+  return status === "supported" || status === "ready";
+}
+
+function getAtomicCapabilityStatus({
+  capabilities,
+  chainId,
+}: {
+  capabilities: NonNullable<ReturnType<typeof useCapabilities>["data"]>;
+  chainId: number;
+}): string | undefined {
+  // `useCapabilities` can return either a chain-scoped capability object or a chain-keyed map.
+  // biome-ignore lint/suspicious/noExplicitAny: Capability shape is a wagmi/viem union here.
+  const directCapabilities = capabilities as any;
+  if (directCapabilities?.atomic?.status) {
+    return directCapabilities.atomic.status;
   }
+
+  return directCapabilities?.[chainId]?.atomic?.status;
 }
 
 async function executeBatched({

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -120,6 +120,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
   const wagmiConfig = useConfig();
   const connection = useConnection();
   const { data: walletClient } = useWalletClient();
+  const [runtimePlan, setRuntimePlan] = useState<PreparedExecutionPlan | null>(null);
   const [progress, setProgress] = useState<StepProgress>({ completedCount: 0, hashes: {} });
 
   const resolvedSwapResult = useMemo(() => {
@@ -177,6 +178,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
     Boolean(resolvedSwapResult.swap && walletClient) && (preparation?.enabled ?? true);
 
   const preparedPlan = useQuery<PreparedExecutionPlan, Error>({
+    ...preparation,
     queryKey: ["spandex", "executeQuote", "plan", progressKey],
     queryFn: async () => {
       const resolvedSwap = resolvedSwapResult.swap;
@@ -201,8 +203,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       });
     },
     enabled: isPreparationEnabled,
-    retry: 0,
-    ...preparation,
+    retry: preparation?.retry ?? 0,
   });
 
   const result = useMutation<
@@ -244,6 +245,8 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
               publicClient,
               allowanceMode: executionAllowanceMode,
             });
+
+      setRuntimePlan(plan);
 
       if (plan.mode === "batched") {
         const transactionHash = await executeBatched({
@@ -315,11 +318,12 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
 
   useEffect(() => {
     void progressKey;
+    setRuntimePlan(null);
     setProgress({ completedCount: 0, hashes: {} });
     result.reset();
   }, [progressKey, result.reset]);
 
-  const activePlan = preparedPlan.data;
+  const activePlan = preparedPlan.data ?? runtimePlan;
   const totalSteps = activePlan?.calls.length ?? 0;
   const currentStepIndex =
     activePlan && progress.completedCount < totalSteps ? progress.completedCount + 1 : null;

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -88,6 +88,7 @@ export type UseExecuteQuoteResult<TOnMutateResult = unknown> = UseMutationResult
   canAutoExecute: boolean;
   isPreparing: boolean;
   isReady: boolean;
+  isExecuting: boolean;
   preparationError: Error | null;
   executeQuote: (
     variables?: ExecuteQuoteVariables,
@@ -359,6 +360,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
   const totalSteps = activePlan?.calls.length ?? 0;
   const currentStepIndex =
     activePlan && progress.completedCount < totalSteps ? progress.completedCount + 1 : null;
+  const isExecuting = result.isPending || Boolean(frozenQuote);
   const currentCall = currentStepIndex ? activePlan?.calls[currentStepIndex - 1] : null;
 
   const steps: ExecuteQuoteStep[] = (activePlan?.calls ?? []).map((call, index) => {
@@ -404,6 +406,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
     canAutoExecute: activePlan ? activePlan.mode !== "stepped" : false,
     isPreparing: preparedPlan.isLoading || preparedPlan.isFetching,
     isReady: Boolean(activePlan),
+    isExecuting,
     preparationError: resolvedSwapResult.error ?? walletError ?? preparedPlan.error ?? null,
     executeQuote: (variables, options) => result.mutate(variables, options),
     executeQuoteAsync: (variables, options) => result.mutateAsync(variables, options),

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -1,17 +1,20 @@
 import {
-  executeQuote as coreExecuteQuote,
+  type BuiltCall,
+  buildCalls,
   type ExactInSwapParams,
   type SuccessfulSimulatedQuote,
   type TargetOutSwapParams,
 } from "@spandex/core";
 import {
-  type UseMutateAsyncFunction,
-  type UseMutateFunction,
+  type MutateOptions,
   type UseMutationOptions,
   type UseMutationResult,
+  type UseQueryOptions,
   useMutation,
+  useQuery,
 } from "@tanstack/react-query";
-import { type PublicClient, publicActions } from "viem";
+import { useEffect, useMemo, useState } from "react";
+import { type Hash, type PublicClient, publicActions, type WalletClient } from "viem";
 import { useConfig, useConnection, useWalletClient } from "wagmi";
 import { useSpandexConfig } from "../context/SpandexProvider.js";
 
@@ -24,81 +27,443 @@ type UseSwapParams = (
 };
 
 type AllowanceMode = "unlimited" | "exact";
+type ExecutionMode = "single" | "batched" | "stepped";
+type ExecutionStepStatus = "pending" | "active" | "complete";
 
 export type ExecuteQuoteVariables = {
-  swap: UseSwapParams;
-  quote: SuccessfulSimulatedQuote;
   allowanceMode?: AllowanceMode;
 };
 
-type ExecuteQuoteData = Awaited<ReturnType<typeof coreExecuteQuote>>;
+export type ExecuteQuoteStep = {
+  index: number;
+  type: BuiltCall["type"];
+  label: string;
+  status: ExecutionStepStatus;
+  hash?: Hash;
+};
+
+export type ExecuteQuoteData = {
+  transactionHash: Hash;
+  mode: ExecutionMode;
+  stepIndex: number;
+  totalSteps: number;
+  action: string;
+  completed: boolean;
+};
+
+type PreparedExecutionPlan = {
+  mode: ExecutionMode;
+  calls: BuiltCall[];
+};
+
+type StepProgress = {
+  completedCount: number;
+  hashes: Record<number, Hash>;
+};
 
 export type UseExecuteQuoteParams<TOnMutateResult = unknown> = {
+  swap: UseSwapParams;
+  quote: SuccessfulSimulatedQuote;
   allowanceMode?: AllowanceMode;
   mutation?: Omit<
-    UseMutationOptions<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>,
+    UseMutationOptions<ExecuteQuoteData, Error, ExecuteQuoteVariables | undefined, TOnMutateResult>,
     "mutationFn"
   >;
+  preparation?: Omit<UseQueryOptions<PreparedExecutionPlan, Error>, "queryKey" | "queryFn">;
 };
 
 export type UseExecuteQuoteResult<TOnMutateResult = unknown> = UseMutationResult<
   ExecuteQuoteData,
   Error,
-  ExecuteQuoteVariables,
+  ExecuteQuoteVariables | undefined,
   TOnMutateResult
 > & {
-  executeQuote: UseMutateFunction<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>;
-  executeQuoteAsync: UseMutateAsyncFunction<
-    ExecuteQuoteData,
-    Error,
-    ExecuteQuoteVariables,
-    TOnMutateResult
-  >;
+  mode: ExecutionMode | null;
+  calls: BuiltCall[];
+  steps: ExecuteQuoteStep[];
+  totalSteps: number;
+  currentStepIndex: number | null;
+  currentActionLabel: string | null;
+  currentStepText: string | null;
+  canAutoExecute: boolean;
+  isPreparing: boolean;
+  isReady: boolean;
+  preparationError: Error | null;
+  executeQuote: (
+    variables?: ExecuteQuoteVariables,
+    options?: MutateOptions<
+      ExecuteQuoteData,
+      Error,
+      ExecuteQuoteVariables | undefined,
+      TOnMutateResult
+    >,
+  ) => void;
+  executeQuoteAsync: (
+    variables?: ExecuteQuoteVariables,
+    options?: MutateOptions<
+      ExecuteQuoteData,
+      Error,
+      ExecuteQuoteVariables | undefined,
+      TOnMutateResult
+    >,
+  ) => Promise<ExecuteQuoteData>;
 };
 
 export function useExecuteQuote<TOnMutateResult = unknown>({
+  swap,
+  quote,
   allowanceMode,
   mutation,
-}: UseExecuteQuoteParams<TOnMutateResult> = {}): UseExecuteQuoteResult<TOnMutateResult> {
+  preparation,
+}: UseExecuteQuoteParams<TOnMutateResult>): UseExecuteQuoteResult<TOnMutateResult> {
   const config = useSpandexConfig();
   const wagmiConfig = useConfig();
   const connection = useConnection();
   const { data: walletClient } = useWalletClient();
+  const [progress, setProgress] = useState<StepProgress>({ completedCount: 0, hashes: {} });
 
-  const result = useMutation<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>({
-    mutationKey: ["spandex", "executeQuote"],
-    ...mutation,
-    mutationFn: async ({ swap, quote, allowanceMode: callAllowanceMode }) => {
-      const resolvedSwap = resolveSwapParams({
-        swap,
-        chainId: connection.chain?.id,
-        swapperAccount: connection.address,
-      });
+  const resolvedSwapResult = useMemo(() => {
+    try {
+      return {
+        swap: resolveSwapParams({
+          swap,
+          chainId: connection.chain?.id,
+          swapperAccount: connection.address,
+        }),
+      };
+    } catch (error) {
+      return { error: error as Error };
+    }
+  }, [swap, connection.chain?.id, connection.address]);
+
+  const publicClient = useMemo(() => {
+    const resolvedSwap = resolvedSwapResult.swap;
+    if (!resolvedSwap) return undefined;
+
+    return wagmiConfig.getClient({ chainId: resolvedSwap.chainId })?.extend(publicActions) as
+      | PublicClient
+      | undefined;
+  }, [wagmiConfig, resolvedSwapResult.swap]);
+
+  const progressKey = useMemo(() => {
+    const resolvedSwap = resolvedSwapResult.swap;
+    return JSON.stringify({
+      chainId: resolvedSwap?.chainId ?? null,
+      swapperAccount: resolvedSwap?.swapperAccount ?? null,
+      inputToken: resolvedSwap?.inputToken ?? null,
+      outputToken: resolvedSwap?.outputToken ?? null,
+      mode: resolvedSwap?.mode ?? null,
+      inputAmount: resolvedSwap?.mode === "exactIn" ? resolvedSwap.inputAmount.toString() : null,
+      outputAmount:
+        resolvedSwap?.mode === "targetOut" ? resolvedSwap.outputAmount.toString() : null,
+      allowanceMode: allowanceMode ?? "exact",
+      provider: quote.provider,
+      quoteTo: quote.txData.to,
+      quoteData: quote.txData.data,
+    });
+  }, [resolvedSwapResult.swap, allowanceMode, quote]);
+
+  const preparedPlan = useQuery<PreparedExecutionPlan, Error>({
+    queryKey: ["spandex", "executeQuote", "plan", progressKey],
+    queryFn: async () => {
+      const resolvedSwap = resolvedSwapResult.swap;
+      if (!resolvedSwap) {
+        throw resolvedSwapResult.error ?? new Error("Unable to resolve swap for execution.");
+      }
 
       if (!walletClient) {
         throw new Error("No WalletClient available from wagmi. Connect a wallet before executing.");
       }
 
-      const publicClient = wagmiConfig
-        .getClient({ chainId: resolvedSwap.chainId })
-        ?.extend(publicActions) as PublicClient | undefined;
-
-      return coreExecuteQuote({
+      return buildPreparedExecutionPlan({
         config,
         quote,
         swap: resolvedSwap,
-        walletClient,
+        walletClient: walletClient as WalletClient,
         publicClient,
-        allowanceMode: callAllowanceMode ?? allowanceMode ?? "exact",
+        allowanceMode: allowanceMode ?? "exact",
       });
+    },
+    enabled: Boolean(resolvedSwapResult.swap && walletClient),
+    retry: 0,
+    ...preparation,
+  });
+
+  const result = useMutation<
+    ExecuteQuoteData,
+    Error,
+    ExecuteQuoteVariables | undefined,
+    TOnMutateResult
+  >({
+    ...mutation,
+    mutationKey: ["spandex", "executeQuote", "mutation", progressKey],
+    mutationFn: async (variables) => {
+      const resolvedSwap = resolvedSwapResult.swap;
+      if (!resolvedSwap) {
+        throw resolvedSwapResult.error ?? new Error("Unable to resolve swap for execution.");
+      }
+
+      if (!walletClient) {
+        throw new Error("No WalletClient available from wagmi. Connect a wallet before executing.");
+      }
+
+      assertWalletChain({
+        walletClient: walletClient as WalletClient,
+        chainId: resolvedSwap.chainId,
+      });
+
+      const plan =
+        preparedPlan.data ??
+        (await buildPreparedExecutionPlan({
+          config,
+          quote,
+          swap: resolvedSwap,
+          walletClient: walletClient as WalletClient,
+          publicClient,
+          allowanceMode: variables?.allowanceMode ?? allowanceMode ?? "exact",
+        }));
+
+      if (plan.mode === "batched") {
+        const transactionHash = await executeBatched({
+          calls: plan.calls,
+          swap: resolvedSwap,
+          walletClient: walletClient as WalletClient,
+        });
+
+        return {
+          transactionHash,
+          mode: "batched",
+          stepIndex: plan.calls.length,
+          totalSteps: plan.calls.length,
+          action: joinActionLabels(plan.calls),
+          completed: true,
+        };
+      }
+
+      const stepIndex = plan.mode === "single" ? 1 : progress.completedCount + 1;
+      const call = plan.calls[stepIndex - 1];
+      if (!call) {
+        throw new Error("All execution steps are already complete.");
+      }
+
+      const transactionHash = await executeSingleCall({
+        call,
+        swap: resolvedSwap,
+        walletClient: walletClient as WalletClient,
+      });
+
+      return {
+        transactionHash,
+        mode: plan.mode,
+        stepIndex,
+        totalSteps: plan.calls.length,
+        action: labelForCall(call),
+        completed: stepIndex >= plan.calls.length,
+      };
+    },
+    onSuccess: async (data, variables, context, mutationContext) => {
+      setProgress((current) => {
+        if (data.mode === "batched") {
+          return { completedCount: data.totalSteps, hashes: current.hashes };
+        }
+
+        return {
+          completedCount: Math.max(current.completedCount, data.stepIndex),
+          hashes: {
+            ...current.hashes,
+            [data.stepIndex]: data.transactionHash,
+          },
+        };
+      });
+
+      await mutation?.onSuccess?.(data, variables, context, mutationContext);
+    },
+    onError: async (error, variables, context, mutationContext) => {
+      await mutation?.onError?.(error, variables, context, mutationContext);
     },
   });
 
+  useEffect(() => {
+    void progressKey;
+    setProgress({ completedCount: 0, hashes: {} });
+    result.reset();
+  }, [progressKey, result.reset]);
+
+  const activePlan = preparedPlan.data;
+  const totalSteps = activePlan?.calls.length ?? 0;
+  const currentStepIndex =
+    activePlan && progress.completedCount < totalSteps ? progress.completedCount + 1 : null;
+  const currentCall = currentStepIndex ? activePlan?.calls[currentStepIndex - 1] : null;
+
+  const steps: ExecuteQuoteStep[] = (activePlan?.calls ?? []).map((call, index) => {
+    const stepIndex = index + 1;
+    const status: ExecutionStepStatus =
+      stepIndex <= progress.completedCount
+        ? "complete"
+        : stepIndex === progress.completedCount + 1
+          ? "active"
+          : "pending";
+
+    return {
+      index: stepIndex,
+      type: call.type,
+      label: labelForCall(call),
+      status,
+      hash: progress.hashes[stepIndex],
+    };
+  });
+
+  const currentActionLabel = activePlan
+    ? activePlan.mode === "batched"
+      ? joinActionLabels(activePlan.calls)
+      : currentCall
+        ? labelForCall(currentCall)
+        : null
+    : null;
+
+  const currentStepText =
+    activePlan?.mode === "stepped" && currentStepIndex
+      ? `Step ${currentStepIndex} of ${totalSteps}`
+      : null;
+
   return {
     ...result,
-    executeQuote: result.mutate,
-    executeQuoteAsync: result.mutateAsync,
+    mode: activePlan?.mode ?? null,
+    calls: activePlan?.calls ?? [],
+    steps,
+    totalSteps,
+    currentStepIndex,
+    currentActionLabel,
+    currentStepText,
+    canAutoExecute: activePlan ? activePlan.mode !== "stepped" : false,
+    isPreparing: preparedPlan.isLoading || preparedPlan.isFetching,
+    isReady: Boolean(activePlan),
+    preparationError: resolvedSwapResult.error ?? preparedPlan.error ?? null,
+    executeQuote: (variables, options) => result.mutate(variables, options),
+    executeQuoteAsync: (variables, options) => result.mutateAsync(variables, options),
   };
+}
+
+async function buildPreparedExecutionPlan({
+  config,
+  quote,
+  swap,
+  walletClient,
+  publicClient,
+  allowanceMode,
+}: {
+  config: ReturnType<typeof useSpandexConfig>;
+  quote: SuccessfulSimulatedQuote;
+  swap: ExactInSwapParams | TargetOutSwapParams;
+  walletClient: WalletClient;
+  publicClient?: PublicClient;
+  allowanceMode: AllowanceMode;
+}): Promise<PreparedExecutionPlan> {
+  const calls = await buildCalls({
+    config,
+    quote,
+    swap,
+    publicClient,
+    allowanceMode,
+  });
+
+  const canBatch = await isBatchSupported(walletClient);
+  return {
+    mode: resolveExecutionMode({ calls, canBatch }),
+    calls,
+  };
+}
+
+function resolveExecutionMode({
+  calls,
+  canBatch,
+}: {
+  calls: BuiltCall[];
+  canBatch: boolean;
+}): ExecutionMode {
+  if (calls.length === 1) {
+    return "single";
+  }
+
+  if (canBatch) {
+    return "batched";
+  }
+
+  return "stepped";
+}
+
+async function isBatchSupported(client: WalletClient): Promise<boolean> {
+  try {
+    const capabilities = await client.getCapabilities({ chainId: client.chain?.id || 0 });
+    return capabilities.atomic?.status === "supported";
+  } catch {
+    return false;
+  }
+}
+
+async function executeBatched({
+  calls,
+  swap,
+  walletClient,
+}: {
+  calls: BuiltCall[];
+  swap: ExactInSwapParams | TargetOutSwapParams;
+  walletClient: WalletClient;
+}): Promise<Hash> {
+  const { receipts, status } = await walletClient.sendCallsSync({
+    chain: walletClient.chain,
+    account: swap.swapperAccount,
+    calls: calls.map((call) => call.txn),
+    throwOnFailure: true,
+  });
+
+  const receipt = receipts?.[receipts.length - 1];
+  if (!receipt || status !== "success") {
+    throw new Error("Atomic transaction execution failed.");
+  }
+
+  return receipt.transactionHash;
+}
+
+async function executeSingleCall({
+  call,
+  swap,
+  walletClient,
+}: {
+  call: BuiltCall;
+  swap: ExactInSwapParams | TargetOutSwapParams;
+  walletClient: WalletClient;
+}): Promise<Hash> {
+  const receipt = await walletClient.sendTransactionSync({
+    chain: walletClient.chain,
+    account: swap.swapperAccount,
+    ...call.txn,
+    throwOnReceiptRevert: true,
+  });
+
+  return receipt.transactionHash;
+}
+
+function assertWalletChain({
+  walletClient,
+  chainId,
+}: {
+  walletClient: WalletClient;
+  chainId: number;
+}) {
+  if (walletClient.chain?.id !== chainId) {
+    throw new Error(
+      `Client chain ID ${walletClient.chain?.id} does not match swap chain ID ${chainId}`,
+    );
+  }
+}
+
+function labelForCall(call: BuiltCall): string {
+  return call.type === "approval" ? "Approve" : "Swap";
+}
+
+function joinActionLabels(calls: BuiltCall[]): string {
+  return calls.map(labelForCall).join(" & ");
 }
 
 function resolveSwapParams({

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -145,23 +145,36 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       | undefined;
   }, [wagmiConfig, resolvedSwapResult.swap]);
 
+  const defaultAllowanceMode = allowanceMode ?? "exact";
+  const walletError =
+    !walletClient && !resolvedSwapResult.error && resolvedSwapResult.swap
+      ? new Error("No WalletClient available from wagmi. Connect a wallet before executing.")
+      : null;
+
   const progressKey = useMemo(() => {
     const resolvedSwap = resolvedSwapResult.swap;
     return JSON.stringify({
+      walletClientUid: walletClient?.uid ?? null,
       chainId: resolvedSwap?.chainId ?? null,
+      outputChainId: resolvedSwap?.outputChainId ?? null,
       swapperAccount: resolvedSwap?.swapperAccount ?? null,
+      recipientAccount: resolvedSwap?.recipientAccount ?? null,
       inputToken: resolvedSwap?.inputToken ?? null,
       outputToken: resolvedSwap?.outputToken ?? null,
       mode: resolvedSwap?.mode ?? null,
+      slippageBps: resolvedSwap?.slippageBps ?? null,
       inputAmount: resolvedSwap?.mode === "exactIn" ? resolvedSwap.inputAmount.toString() : null,
       outputAmount:
         resolvedSwap?.mode === "targetOut" ? resolvedSwap.outputAmount.toString() : null,
-      allowanceMode: allowanceMode ?? "exact",
+      allowanceMode: defaultAllowanceMode,
       provider: quote.provider,
       quoteTo: quote.txData.to,
       quoteData: quote.txData.data,
     });
-  }, [resolvedSwapResult.swap, allowanceMode, quote]);
+  }, [walletClient?.uid, resolvedSwapResult.swap, defaultAllowanceMode, quote]);
+
+  const isPreparationEnabled =
+    Boolean(resolvedSwapResult.swap && walletClient) && (preparation?.enabled ?? true);
 
   const preparedPlan = useQuery<PreparedExecutionPlan, Error>({
     queryKey: ["spandex", "executeQuote", "plan", progressKey],
@@ -172,7 +185,10 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       }
 
       if (!walletClient) {
-        throw new Error("No WalletClient available from wagmi. Connect a wallet before executing.");
+        throw (
+          walletError ??
+          new Error("No WalletClient available from wagmi. Connect a wallet before executing.")
+        );
       }
 
       return buildPreparedExecutionPlan({
@@ -181,10 +197,10 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
         swap: resolvedSwap,
         walletClient: walletClient as WalletClient,
         publicClient,
-        allowanceMode: allowanceMode ?? "exact",
+        allowanceMode: defaultAllowanceMode,
       });
     },
-    enabled: Boolean(resolvedSwapResult.swap && walletClient),
+    enabled: isPreparationEnabled,
     retry: 0,
     ...preparation,
   });
@@ -204,7 +220,10 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
       }
 
       if (!walletClient) {
-        throw new Error("No WalletClient available from wagmi. Connect a wallet before executing.");
+        throw (
+          walletError ??
+          new Error("No WalletClient available from wagmi. Connect a wallet before executing.")
+        );
       }
 
       assertWalletChain({
@@ -212,16 +231,19 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
         chainId: resolvedSwap.chainId,
       });
 
+      const executionAllowanceMode = variables?.allowanceMode ?? defaultAllowanceMode;
+      const shouldRebuildPlan = executionAllowanceMode !== defaultAllowanceMode;
       const plan =
-        preparedPlan.data ??
-        (await buildPreparedExecutionPlan({
-          config,
-          quote,
-          swap: resolvedSwap,
-          walletClient: walletClient as WalletClient,
-          publicClient,
-          allowanceMode: variables?.allowanceMode ?? allowanceMode ?? "exact",
-        }));
+        !shouldRebuildPlan && preparedPlan.data
+          ? preparedPlan.data
+          : await buildPreparedExecutionPlan({
+              config,
+              quote,
+              swap: resolvedSwap,
+              walletClient: walletClient as WalletClient,
+              publicClient,
+              allowanceMode: executionAllowanceMode,
+            });
 
       if (plan.mode === "batched") {
         const transactionHash = await executeBatched({
@@ -264,7 +286,15 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
     onSuccess: async (data, variables, context, mutationContext) => {
       setProgress((current) => {
         if (data.mode === "batched") {
-          return { completedCount: data.totalSteps, hashes: current.hashes };
+          return {
+            completedCount: data.totalSteps,
+            hashes: Object.fromEntries(
+              Array.from({ length: data.totalSteps }, (_, index) => [
+                index + 1,
+                data.transactionHash,
+              ]),
+            ),
+          };
         }
 
         return {
@@ -338,7 +368,7 @@ export function useExecuteQuote<TOnMutateResult = unknown>({
     canAutoExecute: activePlan ? activePlan.mode !== "stepped" : false,
     isPreparing: preparedPlan.isLoading || preparedPlan.isFetching,
     isReady: Boolean(activePlan),
-    preparationError: resolvedSwapResult.error ?? preparedPlan.error ?? null,
+    preparationError: resolvedSwapResult.error ?? walletError ?? preparedPlan.error ?? null,
     executeQuote: (variables, options) => result.mutate(variables, options),
     executeQuoteAsync: (variables, options) => result.mutateAsync(variables, options),
   };

--- a/packages/react/lib/hooks/useExecuteQuote.ts
+++ b/packages/react/lib/hooks/useExecuteQuote.ts
@@ -1,0 +1,150 @@
+import {
+  executeQuote as coreExecuteQuote,
+  type ExactInSwapParams,
+  type SuccessfulSimulatedQuote,
+  type TargetOutSwapParams,
+} from "@spandex/core";
+import {
+  type UseMutateAsyncFunction,
+  type UseMutateFunction,
+  type UseMutationOptions,
+  type UseMutationResult,
+  useMutation,
+} from "@tanstack/react-query";
+import { type PublicClient, publicActions } from "viem";
+import { useConfig, useConnection, useWalletClient } from "wagmi";
+import { useSpandexConfig } from "../context/SpandexProvider.js";
+
+type UseSwapParams = (
+  | Omit<ExactInSwapParams, "chainId" | "swapperAccount">
+  | Omit<TargetOutSwapParams, "chainId" | "swapperAccount">
+) & {
+  chainId?: number;
+  swapperAccount?: `0x${string}`;
+};
+
+type AllowanceMode = "unlimited" | "exact";
+
+export type ExecuteQuoteVariables = {
+  swap: UseSwapParams;
+  quote: SuccessfulSimulatedQuote;
+  allowanceMode?: AllowanceMode;
+};
+
+type ExecuteQuoteData = Awaited<ReturnType<typeof coreExecuteQuote>>;
+
+export type UseExecuteQuoteParams<TOnMutateResult = unknown> = {
+  allowanceMode?: AllowanceMode;
+  mutation?: Omit<
+    UseMutationOptions<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>,
+    "mutationFn"
+  >;
+};
+
+export type UseExecuteQuoteResult<TOnMutateResult = unknown> = UseMutationResult<
+  ExecuteQuoteData,
+  Error,
+  ExecuteQuoteVariables,
+  TOnMutateResult
+> & {
+  executeQuote: UseMutateFunction<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>;
+  executeQuoteAsync: UseMutateAsyncFunction<
+    ExecuteQuoteData,
+    Error,
+    ExecuteQuoteVariables,
+    TOnMutateResult
+  >;
+};
+
+export function useExecuteQuote<TOnMutateResult = unknown>({
+  allowanceMode,
+  mutation,
+}: UseExecuteQuoteParams<TOnMutateResult> = {}): UseExecuteQuoteResult<TOnMutateResult> {
+  const config = useSpandexConfig();
+  const wagmiConfig = useConfig();
+  const connection = useConnection();
+  const { data: walletClient } = useWalletClient();
+
+  const result = useMutation<ExecuteQuoteData, Error, ExecuteQuoteVariables, TOnMutateResult>({
+    mutationKey: ["spandex", "executeQuote"],
+    ...mutation,
+    mutationFn: async ({ swap, quote, allowanceMode: callAllowanceMode }) => {
+      const resolvedSwap = resolveSwapParams({
+        swap,
+        chainId: connection.chain?.id,
+        swapperAccount: connection.address,
+      });
+
+      if (!walletClient) {
+        throw new Error("No WalletClient available from wagmi. Connect a wallet before executing.");
+      }
+
+      const publicClient = wagmiConfig
+        .getClient({ chainId: resolvedSwap.chainId })
+        ?.extend(publicActions) as PublicClient | undefined;
+
+      return coreExecuteQuote({
+        config,
+        quote,
+        swap: resolvedSwap,
+        walletClient,
+        publicClient,
+        allowanceMode: callAllowanceMode ?? allowanceMode ?? "exact",
+      });
+    },
+  });
+
+  return {
+    ...result,
+    executeQuote: result.mutate,
+    executeQuoteAsync: result.mutateAsync,
+  };
+}
+
+function resolveSwapParams({
+  swap,
+  chainId,
+  swapperAccount,
+}: {
+  swap: UseSwapParams;
+  chainId?: number;
+  swapperAccount?: `0x${string}`;
+}): ExactInSwapParams | TargetOutSwapParams {
+  const finalChainId = swap.chainId ?? chainId;
+  if (!finalChainId) {
+    throw new Error(
+      "No chainId provided to useExecuteQuote. Pass swap.chainId or connect a wallet on the target chain.",
+    );
+  }
+
+  const finalSwapperAccount = swap.swapperAccount ?? swapperAccount;
+  if (!finalSwapperAccount) {
+    throw new Error(
+      "No swapperAccount provided to useExecuteQuote. Pass swap.swapperAccount or connect a wallet.",
+    );
+  }
+
+  const baseParams = {
+    chainId: finalChainId,
+    outputChainId: swap.outputChainId,
+    inputToken: swap.inputToken,
+    outputToken: swap.outputToken,
+    slippageBps: swap.slippageBps,
+    swapperAccount: finalSwapperAccount,
+    recipientAccount: swap.recipientAccount,
+  };
+
+  if (swap.mode === "exactIn") {
+    return {
+      ...baseParams,
+      mode: "exactIn",
+      inputAmount: swap.inputAmount,
+    };
+  }
+
+  return {
+    ...baseParams,
+    mode: "targetOut",
+    outputAmount: swap.outputAmount,
+  };
+}

--- a/site/docs/pages/react/hooks/useExecuteQuote.mdx
+++ b/site/docs/pages/react/hooks/useExecuteQuote.mdx
@@ -1,6 +1,12 @@
 # useExecuteQuote
 
-Execute a selected quote with the connected wallet using spanDEX core's execution flow.
+Prepare and execute a selected quote with UI-friendly execution state.
+
+This hook builds the underlying calls up front so your UI can tell whether the route will:
+
+- submit a single swap transaction
+- batch approval and swap into one wallet flow
+- step through approval and swap as separate user actions
 
 ## Example
 
@@ -8,34 +14,27 @@ Execute a selected quote with the connected wallet using spanDEX core's executio
 import { useExecuteQuote, useQuote } from "@spandex/react";
 
 function App() {
+  const swap = {
+    inputToken: "0x4200000000000000000000000000000000000006", // WETH
+    outputToken: "0xd9AAEC86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC
+    mode: "exactIn" as const,
+    inputAmount: 1_000_000_000_000_000_000n, // 1 WETH
+    slippageBps: 50,
+  };
+
   const { data: quote } = useQuote({
-    swap: {
-      inputToken: "0x4200000000000000000000000000000000000006", // WETH
-      outputToken: "0xd9AAEC86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC
-      mode: "exactIn",
-      inputAmount: 1_000_000_000_000_000_000n, // 1 WETH
-      slippageBps: 50,
-    },
+    swap,
     strategy: "bestPrice",
   });
 
-  const { executeQuoteAsync, data, isPending, error } = useExecuteQuote({
+  const execution = useExecuteQuote({
+    swap,
+    quote: quote!,
     allowanceMode: "exact",
   });
 
   async function onSubmit() {
-    if (!quote) return;
-
-    await executeQuoteAsync({
-      swap: {
-        inputToken: "0x4200000000000000000000000000000000000006",
-        outputToken: "0xd9AAEC86B65D86f6A7B5B1b0c42FFA531710b6CA",
-        mode: "exactIn",
-        inputAmount: 1_000_000_000_000_000_000n,
-        slippageBps: 50,
-      },
-      quote,
-    });
+    await execution.executeQuoteAsync();
   }
 }
 ```
@@ -44,9 +43,42 @@ function App() {
 
 ```ts
 {
-  executeQuote: (variables) => void;
-  executeQuoteAsync: (variables) => Promise<{ transactionHash: `0x${string}` }>;
-  data: { transactionHash: `0x${string}` } | undefined;
+  mode: "single" | "batched" | "stepped" | null;
+  calls: BuiltCall[];
+  steps: Array<{
+    index: number;
+    type: "approval" | "swap";
+    label: string;
+    status: "pending" | "active" | "complete";
+    hash?: `0x${string}`;
+  }>;
+  totalSteps: number;
+  currentStepIndex: number | null;
+  currentActionLabel: string | null;
+  currentStepText: string | null;
+  canAutoExecute: boolean;
+  isPreparing: boolean;
+  isReady: boolean;
+  preparationError: Error | null;
+  executeQuote: (variables?: { allowanceMode?: "exact" | "unlimited" }) => void;
+  executeQuoteAsync: (
+    variables?: { allowanceMode?: "exact" | "unlimited" },
+  ) => Promise<{
+    transactionHash: `0x${string}`;
+    mode: "single" | "batched" | "stepped";
+    stepIndex: number;
+    totalSteps: number;
+    action: string;
+    completed: boolean;
+  }>;
+  data: {
+    transactionHash: `0x${string}`;
+    mode: "single" | "batched" | "stepped";
+    stepIndex: number;
+    totalSteps: number;
+    action: string;
+    completed: boolean;
+  } | undefined;
   isPending: boolean;
   error: Error | null;
   // ...other React Query mutation return values
@@ -54,19 +86,6 @@ function App() {
 ```
 
 ## Params
-
-### allowanceMode
-
-Optional default approval mode for executions triggered through this hook. Supported values are
-`"exact"` and `"unlimited"`. You can override this per call by passing `allowanceMode` to
-`executeQuote` or `executeQuoteAsync`.
-
-### mutation
-
-Optional React Query mutation overrides such as `onSuccess`, `onError`, `retry`, or
-`mutationKey`. The mutation function is managed by spanDEX and cannot be replaced.
-
-## Execution Variables
 
 ### swap
 
@@ -79,11 +98,24 @@ A `SuccessfulSimulatedQuote`, typically returned by `useQuote` or selected from 
 
 ### allowanceMode
 
-Optional per-call override for the approval mode.
+Optional default approval mode. Supported values are `"exact"` and `"unlimited"`. You can override
+this per execution call.
+
+### mutation
+
+Optional React Query mutation overrides such as `onSuccess`, `onError`, or `retry`. The mutation
+function is managed by spanDEX and cannot be replaced.
+
+### preparation
+
+Optional React Query query overrides for the execution plan preparation step. This is useful if you
+want to tune when the hook precomputes execution calls.
 
 ## Notes
 
-- The hook reads spanDEX config from `useSpandexConfig`.
-- It uses Wagmi's connected wallet client for execution.
-- It resolves the public client from the active Wagmi config for the swap chain.
-- The selected quote must already be successful and simulated.
+- `mode === "single"` means the route can execute in one transaction.
+- `mode === "batched"` means the wallet supports sending all calls together.
+- `mode === "stepped"` means the UI should walk the user through multiple clicks.
+- In the stepped path, each `executeQuote` call advances one step.
+- `currentActionLabel` and `currentStepText` are intended for button labels and helper text such as
+  `Approve` and `Step 1 of 2`.

--- a/site/docs/pages/react/hooks/useExecuteQuote.mdx
+++ b/site/docs/pages/react/hooks/useExecuteQuote.mdx
@@ -1,0 +1,89 @@
+# useExecuteQuote
+
+Execute a selected quote with the connected wallet using spanDEX core's execution flow.
+
+## Example
+
+```ts twoslash
+import { useExecuteQuote, useQuote } from "@spandex/react";
+
+function App() {
+  const { data: quote } = useQuote({
+    swap: {
+      inputToken: "0x4200000000000000000000000000000000000006", // WETH
+      outputToken: "0xd9AAEC86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC
+      mode: "exactIn",
+      inputAmount: 1_000_000_000_000_000_000n, // 1 WETH
+      slippageBps: 50,
+    },
+    strategy: "bestPrice",
+  });
+
+  const { executeQuoteAsync, data, isPending, error } = useExecuteQuote({
+    allowanceMode: "exact",
+  });
+
+  async function onSubmit() {
+    if (!quote) return;
+
+    await executeQuoteAsync({
+      swap: {
+        inputToken: "0x4200000000000000000000000000000000000006",
+        outputToken: "0xd9AAEC86B65D86f6A7B5B1b0c42FFA531710b6CA",
+        mode: "exactIn",
+        inputAmount: 1_000_000_000_000_000_000n,
+        slippageBps: 50,
+      },
+      quote,
+    });
+  }
+}
+```
+
+## Returns
+
+```ts
+{
+  executeQuote: (variables) => void;
+  executeQuoteAsync: (variables) => Promise<{ transactionHash: `0x${string}` }>;
+  data: { transactionHash: `0x${string}` } | undefined;
+  isPending: boolean;
+  error: Error | null;
+  // ...other React Query mutation return values
+}
+```
+
+## Params
+
+### allowanceMode
+
+Optional default approval mode for executions triggered through this hook. Supported values are
+`"exact"` and `"unlimited"`. You can override this per call by passing `allowanceMode` to
+`executeQuote` or `executeQuoteAsync`.
+
+### mutation
+
+Optional React Query mutation overrides such as `onSuccess`, `onError`, `retry`, or
+`mutationKey`. The mutation function is managed by spanDEX and cannot be replaced.
+
+## Execution Variables
+
+### swap
+
+Swap parameters for the quote you want to execute. `chainId` and `swapperAccount` are optional and
+will be inferred from the current Wagmi connection when omitted.
+
+### quote
+
+A `SuccessfulSimulatedQuote`, typically returned by `useQuote` or selected from `useQuotes`.
+
+### allowanceMode
+
+Optional per-call override for the approval mode.
+
+## Notes
+
+- The hook reads spanDEX config from `useSpandexConfig`.
+- It uses Wagmi's connected wallet client for execution.
+- It resolves the public client from the active Wagmi config for the swap chain.
+- The selected quote must already be successful and simulated.

--- a/site/docs/pages/react/hooks/useQuoteExecutor.mdx
+++ b/site/docs/pages/react/hooks/useQuoteExecutor.mdx
@@ -1,7 +1,0 @@
-import { Callout } from 'vocs/components'
-
-# useQuoteExecutor
-
-<Callout type="warning">
-  Coming soon
-</Callout>

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -150,8 +150,8 @@ export default defineConfig({
               link: "/react/hooks/useQuotes",
             },
             {
-              text: "useQuoteExecutor",
-              link: "/react/hooks/useQuoteExecutor",
+              text: "useExecuteQuote",
+              link: "/react/hooks/useExecuteQuote",
             },
           ],
         },


### PR DESCRIPTION
## Changes

Implements `useExecuteQuote` in `@spandex/react` as the React/Wagmi mutation hook for executing a selected quote.

This PR:

- adds `useExecuteQuote` to wrap core `executeQuote`
- defaults `swap.chainId` and `swapperAccount` from Wagmi connection state, like the existing quote hooks
- supports hook-level and per-call `allowanceMode`
- exports the hook from `@spandex/react`
- adds focused React tests for execution flow and override behavior
- renames the docs placeholder from `useQuoteExecutor` to `useExecuteQuote`
- updates the React hooks docs nav entry
- includes a changeset for the new public React API


## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change does not impact released packages (tests,docs,examples) (no release).