### PR TITLE
fix: harden simulation error message parsing

### DIFF
--- a/examples/react/src/components/IntentCapture/index.tsx
+++ b/examples/react/src/components/IntentCapture/index.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/utils/errors";
 import {
   getBestQuoteByMetric,
+  getErrorMessage,
   getSimulationFailureReason,
   type Metric,
 } from "@/utils/quoteHelpers";
@@ -199,10 +200,11 @@ export function IntentCapture() {
 
     if (failedSimQuote) {
       const reason = getSimulationFailureReason(failedSimQuote, allowance);
+      const details = getErrorMessage(failedSimQuote.simulation.error);
       state.simulation.push({
         title: reason || "Simulation failed",
         description: "This swap will likely fail if executed",
-        details: failedSimQuote.simulation.error.message,
+        details: details || "Simulation failed",
         cause: failedSimQuote.simulation,
       });
     }

--- a/examples/react/src/utils/quoteHelpers.ts
+++ b/examples/react/src/utils/quoteHelpers.ts
@@ -121,13 +121,23 @@ export function getQuoteInaccuracy(quote?: SimulatedQuote): number | null {
   return Math.round((diff / quotedOutput) * 10000);
 }
 
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "";
+}
+
 export function getSimulationFailureReason(
   quote: SimulatedQuote,
   currentAllowance?: bigint,
 ): string | null {
   if (!quote.success || quote.simulation.success) return null;
 
-  const errorMessage = quote.simulation.error.message.toLowerCase();
+  const errorMessage = getErrorMessage(quote.simulation.error).toLowerCase();
 
   if (errorMessage.includes("transfer_from_failed") || errorMessage.includes("transferfrom")) {
     if (currentAllowance !== undefined && quote.inputAmount > currentAllowance) {


### PR DESCRIPTION
## Changes

Shallow simulation error message parsing crashes the react example on failure. Check for more message types + shapes to prevent client crashes when simulations fail.

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `bun test`.

## Release Impact

- [ ] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change does not impact released packages (tests,docs,examples) (no release).