### PR TITLE
feat: user defined state overrides for simulation

### DIFF
--- a/.changeset/calm-swaps-simulate.md
+++ b/.changeset/calm-swaps-simulate.md
@@ -1,0 +1,5 @@
+---
+"@spandex/core": minor
+---
+
+Add caller-provided state overrides to quote simulation, including delegated proxy simulation.

--- a/examples/hono/src/index.ts
+++ b/examples/hono/src/index.ts
@@ -1,12 +1,13 @@
 import { zValidator } from "@hono/zod-validator";
 import {
+  deserializeWithBigInt,
   newStream,
   prepareQuotes,
   prepareSimulatedQuotes,
   quoteStreamErrorHandler,
   simulatedQuoteStreamErrorHandler,
   type Quote,
-  type SwapParams,
+  type SimulationOptions,
 } from "@spandex/core";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
@@ -28,6 +29,7 @@ const baseSchema = z.object({
   slippageBps: z.coerce.number().int().nonnegative().max(10000),
   swapperAccount: addressSchema,
   recipientAccount: addressSchema.optional(),
+  simulationOptions: z.string().optional(),
 });
 
 const querySchema = z.discriminatedUnion("mode", [
@@ -45,7 +47,7 @@ const querySchema = z.discriminatedUnion("mode", [
 
 // Stream raw quotes as they are fetched
 app.get("/api/v1/prepareQuotes", zValidator("query", querySchema), async (c) => {
-  const swap = c.req.valid("query") satisfies SwapParams;
+  const { simulationOptions: _, ...swap } = c.req.valid("query");
   return stream(c, async (stream) => {
     const prepared = await prepareQuotes<Quote>({
       swap,
@@ -58,11 +60,15 @@ app.get("/api/v1/prepareQuotes", zValidator("query", querySchema), async (c) => 
 
 // Stream simulated quotes as they are fetched and simulated
 app.get("/api/v1/prepareSimulatedQuotes", zValidator("query", querySchema), async (c) => {
-  const swap = c.req.valid("query") satisfies SwapParams;
+  const { simulationOptions: encodedSimulationOptions, ...swap } = c.req.valid("query");
+  const simulationOptions = encodedSimulationOptions
+    ? deserializeWithBigInt<SimulationOptions>(encodedSimulationOptions)
+    : undefined;
   return stream(c, async (stream) => {
     const prepared = await prepareSimulatedQuotes({
       swap,
       config,
+      simulationOptions,
     });
     await stream.pipe(newStream(prepared, simulatedQuoteStreamErrorHandler));
   });

--- a/examples/react/src/routes/api/prepareSimulatedQuotes.ts
+++ b/examples/react/src/routes/api/prepareSimulatedQuotes.ts
@@ -1,6 +1,11 @@
 import { newStream, prepareSimulatedQuotes, simulatedQuoteStreamErrorHandler } from "@spandex/core";
 import { createFileRoute } from "@tanstack/react-router";
-import { parseSwapFromRequest, proxyConfig, quoteQuerySchema } from "./quoteProxy";
+import {
+  parseSimulationOptionsFromRequest,
+  parseSwapFromRequest,
+  proxyConfig,
+  quoteQuerySchema,
+} from "./quoteProxy";
 
 export const Route = createFileRoute("/api/prepareSimulatedQuotes")({
   validateSearch: (search) => quoteQuerySchema.parse(search),
@@ -8,9 +13,11 @@ export const Route = createFileRoute("/api/prepareSimulatedQuotes")({
     handlers: {
       GET: async ({ request }) => {
         const swap = parseSwapFromRequest(request);
+        const simulationOptions = parseSimulationOptionsFromRequest(request);
         const promises = await prepareSimulatedQuotes({
           swap,
           config: proxyConfig,
+          simulationOptions,
         });
         return new Response(newStream(promises, simulatedQuoteStreamErrorHandler));
       },

--- a/examples/react/src/routes/api/quoteProxy.ts
+++ b/examples/react/src/routes/api/quoteProxy.ts
@@ -1,4 +1,12 @@
-import { createConfig, defaultProviders, o1, type SwapParams, zeroX } from "@spandex/core";
+import {
+  createConfig,
+  defaultProviders,
+  deserializeWithBigInt,
+  o1,
+  type SimulationOptions,
+  type SwapParams,
+  zeroX,
+} from "@spandex/core";
 import { createPublicClient } from "viem";
 import { z } from "zod";
 import { configuredChains } from "@/config/onchain";
@@ -30,6 +38,7 @@ const baseSchema = z.object({
   slippageBps: z.coerce.number().int().nonnegative().max(10000),
   swapperAccount: addressSchema,
   recipientAccount: addressSchema.optional(),
+  simulationOptions: z.string().optional(),
 });
 
 export const quoteQuerySchema = z.discriminatedUnion("mode", [
@@ -44,7 +53,17 @@ export const quoteQuerySchema = z.discriminatedUnion("mode", [
 ]);
 
 export function parseSwapFromRequest(request: Request): SwapParams {
-  return quoteQuerySchema.parse(
-    Object.fromEntries(new URL(request.url).searchParams),
-  ) satisfies SwapParams;
+  const { simulationOptions: _, ...swap } = parseQuoteQuery(request);
+  return swap;
+}
+
+export function parseSimulationOptionsFromRequest(request: Request): SimulationOptions | undefined {
+  const { simulationOptions } = parseQuoteQuery(request);
+  return simulationOptions
+    ? deserializeWithBigInt<SimulationOptions>(simulationOptions)
+    : undefined;
+}
+
+function parseQuoteQuery(request: Request) {
+  return quoteQuerySchema.parse(Object.fromEntries(new URL(request.url).searchParams));
 }

--- a/packages/core/lib/getQuote.test.ts
+++ b/packages/core/lib/getQuote.test.ts
@@ -6,13 +6,23 @@ import { getQuote } from "./getQuote.js";
 import { prepareSimulatedQuotes } from "./prepareSimulatedQuotes.js";
 import type {
   SimulationArgs,
+  SimulationOptions,
   SimulationSuccess,
   SuccessfulSimulatedQuote,
   SwapParams,
 } from "./types.js";
 
 const mockPrepareSimulatedQuotes = mock(
-  ({ config, swap, client }: { config: Config; swap: SwapParams; client?: PublicClient }) => {
+  ({
+    config,
+    swap,
+    client,
+  }: {
+    config: Config;
+    swap: SwapParams;
+    client?: PublicClient;
+    simulationOptions?: SimulationOptions;
+  }) => {
     const resolvedClient = client ?? ({} as PublicClient);
     return config.aggregators.map((aggregator) =>
       aggregator
@@ -114,5 +124,34 @@ describe("getQuote", () => {
     });
     expect(best).toBeDefined();
     expect(best?.simulation.outputAmount).toBe(900_001n);
+  });
+
+  it("passes simulationOptions to simulation preparation", async () => {
+    const config: Config = {
+      aggregators: [new MockAggregator(quoteSuccess)],
+      options: {},
+      clientLookup: () => undefined,
+    };
+    const simulationOptions: SimulationOptions = {
+      stateOverrides: [
+        {
+          address: defaultSwapParams.swapperAccount,
+          balance: 123n,
+        },
+      ],
+    };
+
+    await getQuote({
+      config,
+      swap: defaultSwapParams,
+      strategy: "fastest",
+      client: {} as PublicClient,
+      simulationOptions,
+    });
+
+    const lastCall = mockPrepareSimulatedQuotes.mock.calls.at(-1)?.[0] as {
+      simulationOptions?: SimulationOptions;
+    };
+    expect(lastCall?.simulationOptions).toEqual(simulationOptions);
   });
 });

--- a/packages/core/lib/getQuote.ts
+++ b/packages/core/lib/getQuote.ts
@@ -2,7 +2,12 @@ import type { PublicClient } from "viem";
 import type { Config } from "./createConfig.js";
 import { prepareSimulatedQuotes } from "./prepareSimulatedQuotes.js";
 import { selectQuote } from "./selectQuote.js";
-import type { QuoteSelectionStrategy, SuccessfulSimulatedQuote, SwapParams } from "./types.js";
+import type {
+  QuoteSelectionStrategy,
+  SimulationOptions,
+  SuccessfulSimulatedQuote,
+  SwapParams,
+} from "./types.js";
 
 /**
  * Fetches quotes, simulates them, and selects a winner using the provided strategy.
@@ -12,6 +17,7 @@ import type { QuoteSelectionStrategy, SuccessfulSimulatedQuote, SwapParams } fro
  * @param params.swap - Swap request parameters.
  * @param params.strategy - Strategy used to pick the winning quote.
  * @param params.client - Optional public client used for simulation.
+ * @param params.simulationOptions - Optional simulation controls, including state overrides.
  * @returns Winning quote, or `null` if no provider succeeds.
  */
 export async function getQuote({
@@ -19,16 +25,19 @@ export async function getQuote({
   swap,
   strategy,
   client,
+  simulationOptions,
 }: {
   config: Config;
   swap: SwapParams;
   strategy: QuoteSelectionStrategy;
   client?: PublicClient;
+  simulationOptions?: SimulationOptions;
 }): Promise<SuccessfulSimulatedQuote | null> {
   const quotes = await prepareSimulatedQuotes({
     config,
     swap,
     client,
+    simulationOptions,
   });
   return selectQuote({
     strategy,

--- a/packages/core/lib/getQuotes.ts
+++ b/packages/core/lib/getQuotes.ts
@@ -1,7 +1,7 @@
 import type { PublicClient } from "viem";
 import type { Config } from "./createConfig.js";
 import { prepareSimulatedQuotes } from "./prepareSimulatedQuotes.js";
-import type { SimulatedQuote, SwapParams } from "./types.js";
+import type { SimulatedQuote, SimulationOptions, SwapParams } from "./types.js";
 
 /**
  * Fetches quotes from all providers and simulates execution using the provided or configured client.
@@ -10,16 +10,19 @@ import type { SimulatedQuote, SwapParams } from "./types.js";
  * @param params.config - Meta-aggregator configuration.
  * @param params.swap - Swap request parameters.
  * @param params.client - Public client used to simulate quote transaction data.
+ * @param params.simulationOptions - Optional simulation controls, including state overrides.
  * @returns Quotes enriched with simulation metadata.
  */
 export async function getQuotes({
   config,
   swap,
   client,
+  simulationOptions,
 }: {
   config: Config;
   swap: SwapParams;
   client?: PublicClient;
+  simulationOptions?: SimulationOptions;
 }): Promise<SimulatedQuote[]> {
-  return Promise.all(await prepareSimulatedQuotes({ config, swap, client }));
+  return Promise.all(await prepareSimulatedQuotes({ config, swap, client, simulationOptions }));
 }

--- a/packages/core/lib/prepareSimulatedQuotes.ts
+++ b/packages/core/lib/prepareSimulatedQuotes.ts
@@ -2,7 +2,7 @@ import type { PublicClient } from "viem";
 import type { Config } from "./createConfig.js";
 import { prepareQuotes } from "./prepareQuotes.js";
 import { simulateQuote } from "./simulateQuote.js";
-import type { Quote, SimulatedQuote, SwapParams } from "./types.js";
+import type { Quote, SimulatedQuote, SimulationOptions, SwapParams } from "./types.js";
 
 /**
  * Prepares simulated quotes by fetching quotes from all configured aggregators then simulating them.
@@ -11,19 +11,22 @@ import type { Quote, SimulatedQuote, SwapParams } from "./types.js";
  * @param params.config - Meta-aggregator configuration.
  * @param params.swap - Swap request parameters.
  * @param params.client - Public client used to simulate quote transaction data.
+ * @param params.simulationOptions - Optional simulation controls, including state overrides.
  * @returns Quotes enriched with simulation metadata.
  */
 export async function prepareSimulatedQuotes({
   config,
   swap,
   client,
+  simulationOptions,
 }: {
   config: Config;
   swap: SwapParams;
   client?: PublicClient;
+  simulationOptions?: SimulationOptions;
 }): Promise<Promise<SimulatedQuote>[]> {
   if (config.proxy?.isDelegatedAction("prepareSimulatedQuotes")) {
-    return config.proxy.prepareSimulatedQuotes(swap);
+    return config.proxy.prepareSimulatedQuotes(swap, simulationOptions);
   }
 
   if (config.proxy && config.aggregators.length === 0) {
@@ -44,6 +47,7 @@ export async function prepareSimulatedQuotes({
       client: resolved as PublicClient,
       swap,
       quote,
+      simulationOptions,
     });
   };
 

--- a/packages/core/lib/simulateQuote.stateOverrides.test.ts
+++ b/packages/core/lib/simulateQuote.stateOverrides.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "bun:test";
+import type { PublicClient, StateOverride } from "viem";
+import { parseEther, toHex } from "viem";
+import { base } from "viem/chains";
+import { defaultSwapParams, quoteSuccess } from "../test/utils.js";
+import { mergeSimulationStateOverrides, simulateQuote, simulateQuotes } from "./simulateQuote.js";
+import type { SimulationOptions, SuccessfulQuote } from "./types.js";
+
+const slot = toHex(1n, { size: 32 });
+const slotValue = toHex(500_000_000n, { size: 32 });
+
+describe("simulation state overrides", () => {
+  it("keeps defaults, adds other accounts, and lets caller values win", () => {
+    const swapper = "0x2222222222222222222222222222222222222222";
+    const token = "0x4444444444444444444444444444444444444444";
+    const base: StateOverride = [{ address: swapper, balance: parseEther("10000") }];
+    const extra: StateOverride = [
+      {
+        address: swapper,
+        balance: 123n,
+        stateDiff: [{ slot: "0x01", value: "0x02" }],
+      },
+      {
+        address: token,
+        balance: 1n,
+      },
+    ];
+
+    expect(mergeSimulationStateOverrides(base, extra)).toEqual([
+      {
+        address: swapper,
+        balance: 123n,
+        stateDiff: [{ slot: "0x01", value: "0x02" }],
+      },
+      {
+        address: token,
+        balance: 1n,
+      },
+    ]);
+  });
+
+  it("matches addresses and storage slots case-insensitively", () => {
+    const lowerAddress = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+    const upperAddress = "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD";
+    const merged = mergeSimulationStateOverrides(
+      [
+        {
+          address: lowerAddress,
+          stateDiff: [
+            { slot: "0xAA", value: "0x01" },
+            { slot: "0xbb", value: "0x02" },
+          ],
+        },
+      ],
+      [
+        {
+          address: upperAddress,
+          stateDiff: [
+            { slot: "0xaa", value: "0x03" },
+            { slot: "0xCC", value: "0x04" },
+          ],
+        },
+      ],
+    );
+
+    expect(merged).toEqual([
+      {
+        address: upperAddress,
+        stateDiff: [
+          { slot: "0xaa", value: "0x03" },
+          { slot: "0xbb", value: "0x02" },
+          { slot: "0xCC", value: "0x04" },
+        ],
+      },
+    ]);
+  });
+
+  it("uses an incoming full state instead of an existing stateDiff", () => {
+    const address = "0x3333333333333333333333333333333333333333";
+    const merged = mergeSimulationStateOverrides(
+      [{ address, stateDiff: [{ slot: "0x01", value: "0x01" }] }],
+      [{ address, state: [{ slot: "0x02", value: "0x02" }] }],
+    );
+
+    expect(merged).toEqual([
+      {
+        address,
+        state: [{ slot: "0x02", value: "0x02" }],
+      },
+    ]);
+  });
+
+  it("uses an incoming stateDiff instead of an existing full state", () => {
+    const address = "0x3333333333333333333333333333333333333333";
+    const merged = mergeSimulationStateOverrides(
+      [{ address, state: [{ slot: "0x01", value: "0x01" }] }],
+      [{ address, stateDiff: [{ slot: "0x02", value: "0x02" }] }],
+    );
+
+    expect(merged).toEqual([
+      {
+        address,
+        stateDiff: [{ slot: "0x02", value: "0x02" }],
+      },
+    ]);
+  });
+
+  it("injects merged overrides into same-chain simulateCalls", async () => {
+    const requests: CapturedRequest[] = [];
+    const client = createSimulationClient(requests);
+    const simulationOptions: SimulationOptions = {
+      stateOverrides: [
+        {
+          address: defaultSwapParams.swapperAccount,
+          balance: 123n,
+        },
+        {
+          address: defaultSwapParams.inputToken,
+          stateDiff: [{ slot, value: slotValue }],
+        },
+      ],
+    };
+
+    const quote = await simulateQuote({
+      client,
+      swap: defaultSwapParams,
+      quote: validQuote(),
+      simulationOptions,
+    });
+
+    expect(quote.simulation.success).toBe(true);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.params[0].blockStateCalls[0]?.stateOverrides).toEqual({
+      [defaultSwapParams.swapperAccount]: {
+        balance: "0x7b",
+      },
+      [defaultSwapParams.inputToken]: {
+        stateDiff: {
+          [slot]: slotValue,
+        },
+      },
+    });
+  });
+
+  it("threads overrides through batch cross-chain simulation", async () => {
+    const requests: CapturedRequest[] = [];
+    const client = createSimulationClient(requests);
+    const crossChainSwap = {
+      ...defaultSwapParams,
+      outputChainId: 10,
+    };
+    const simulationOptions: SimulationOptions = {
+      stateOverrides: [
+        {
+          address: defaultSwapParams.inputToken,
+          stateDiff: [{ slot, value: slotValue }],
+        },
+      ],
+    };
+
+    const quotes = await simulateQuotes({
+      client,
+      swap: crossChainSwap,
+      quotes: [{ ...validQuote(), outputChainId: 10 }],
+      simulationOptions,
+    });
+
+    expect(quotes[0]?.simulation.success).toBe(true);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.params[0].blockStateCalls[0]?.stateOverrides).toEqual({
+      [defaultSwapParams.swapperAccount]: {
+        balance: toHex(parseEther("10000")),
+      },
+      [defaultSwapParams.inputToken]: {
+        stateDiff: {
+          [slot]: slotValue,
+        },
+      },
+    });
+  });
+});
+
+type CapturedRequest = {
+  method: string;
+  params: [
+    {
+      blockStateCalls: Array<{
+        calls: unknown[];
+        stateOverrides?: Record<string, unknown>;
+      }>;
+    },
+    unknown,
+  ];
+};
+
+function validQuote(): SuccessfulQuote {
+  return {
+    ...quoteSuccess,
+    txData: {
+      to: "0x1111111111111111111111111111111111111111",
+      data: "0x",
+    },
+  };
+}
+
+function createSimulationClient(requests: CapturedRequest[]): PublicClient {
+  return {
+    chain: base,
+    request: async (request: CapturedRequest) => {
+      requests.push(request);
+      const calls = request.params[0].blockStateCalls[0]?.calls ?? [];
+      return [
+        {
+          number: "0x1",
+          calls: calls.map((_, index) => ({
+            status: "0x1",
+            gasUsed: "0x1",
+            returnData:
+              index === 1
+                ? toHex(100n, { size: 32 })
+                : index === 3
+                  ? toHex(200n, { size: 32 })
+                  : "0x",
+          })),
+        },
+      ];
+    },
+  } as unknown as PublicClient;
+}

--- a/packages/core/lib/simulateQuote.test.ts
+++ b/packages/core/lib/simulateQuote.test.ts
@@ -1,34 +1,24 @@
 import { describe, expect, it } from "bun:test";
-import type { Address, PublicClient } from "viem";
-import { createPublicClient, http } from "viem";
-import { base } from "viem/chains";
-import { createConfig, fabric, getRawQuotes, kyberswap, type SwapParams } from "../index.js";
+import type { Address } from "viem";
+import { toHex } from "viem";
+import { fabric, getQuote, getRawQuotes, kyberswap } from "../index.js";
+import { defaultSwapParams, testConfig, USDC_WHALE } from "../test/utils.js";
 import { simulateQuotes } from "./simulateQuote.js";
 import type { SimulatedQuote } from "./types.js";
 
-const defaultSwapParams: SwapParams = {
-  chainId: 8453,
-  inputToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  outputToken: "0x4200000000000000000000000000000000000006",
-  inputAmount: 500_000_000n,
-  slippageBps: 100,
-  swapperAccount: "0xdead00000000000000000000000000000000beef",
-  mode: "exactIn",
-};
-
-const ANKR_API_KEY = process.env.ANKR_API_KEY || "";
-const USDC_WHALE: Address = "0xEe7aE85f2Fe2239E27D9c1E23fFFe168D63b4055";
+const FABRIC_VANITY_ACCOUNT: Address = "0x0fabfabfabfabfabfabfabfabfabfabfabfabfab";
+const FABRIC_VANITY_USDC_BALANCE_SLOT =
+  "0xaaabaa18f16f048d904f82d05042c130143069b2ff150f1c4b085d0d21e2c9b2";
 
 describe("simulateQuote", () => {
-  const client = createPublicClient({
-    chain: base,
-    transport: http(`https://rpc.ankr.com/base/${ANKR_API_KEY}`),
-  }) as PublicClient;
-
-  const config = createConfig({
-    providers: [kyberswap({ clientId: "spandex-test-env" }), fabric({ appId: "spandex-test-env" })],
-    clients: [client] as PublicClient[],
-  });
+  const config = testConfig([
+    kyberswap({ clientId: "spandex-test-env" }),
+    fabric({ appId: "spandex-test-env" }),
+  ]);
+  const client = config.clientLookup(defaultSwapParams.chainId);
+  if (!client) {
+    throw new Error("Base PublicClient is not configured");
+  }
 
   it("simulates quotes", async () => {
     const swapParams = {
@@ -57,6 +47,43 @@ describe("simulateQuote", () => {
       }
     }
   }, 30000);
+
+  it("simulates an indicative Base swap with a USDC balance override", async () => {
+    const swapParams = {
+      ...defaultSwapParams,
+      swapperAccount: FABRIC_VANITY_ACCOUNT,
+    };
+    if (swapParams.mode !== "exactIn") {
+      throw new Error("Expected the default swap to use exact-input mode");
+    }
+
+    const quote = await getQuote({
+      config: testConfig([fabric({ appId: "spandex-test-env" })]),
+      swap: swapParams,
+      strategy: "fastest",
+      simulationOptions: {
+        stateOverrides: [
+          {
+            address: swapParams.inputToken,
+            stateDiff: [
+              {
+                slot: FABRIC_VANITY_USDC_BALANCE_SLOT,
+                value: toHex(swapParams.inputAmount, { size: 32 }),
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(quote).not.toBeNull();
+    if (!quote) {
+      throw new Error("Expected a successful simulated quote");
+    }
+    expect(quote.simulation.outputAmount).toBeGreaterThan(0n);
+    expect(quote.simulation.gasUsed ?? 0n).toBeGreaterThan(0n);
+    expect(quote.simulation.approvalGasUsed ?? 0n).toBeGreaterThan(0n);
+  }, 30_000);
 });
 
 function summarize(quote: SimulatedQuote) {

--- a/packages/core/lib/simulateQuote.ts
+++ b/packages/core/lib/simulateQuote.ts
@@ -1,4 +1,4 @@
-import type { Address, Block, PublicClient, SimulateCallsReturnType } from "viem";
+import type { Address, Block, PublicClient, SimulateCallsReturnType, StateOverride } from "viem";
 import { encodeFunctionData, erc20Abi, parseEther } from "viem";
 import { simulateCalls } from "viem/actions";
 import type {
@@ -67,18 +67,20 @@ export class SimulationRevertError extends Error {
  * @param args.swap - Swap parameters shared across all quotes.
  * @param args.client - Public client used to perform the simulations.
  * @param args.quotes - Quotes that should be simulated.
+ * @param args.simulationOptions - Optional simulation controls, including state overrides.
  * @returns Quotes decorated with their simulation results.
  */
 export async function simulateQuotes(
   args: Omit<SimulationArgs, "quote"> & { quotes: Quote[] },
 ): Promise<SimulatedQuote[]> {
-  const { swap, client, quotes } = args;
+  const { swap, client, quotes, simulationOptions } = args;
   return Promise.all(
     quotes.map(async (quote: Quote) => {
       return simulateQuote({
         client,
         swap,
         quote,
+        simulationOptions,
       });
     }),
   );
@@ -91,6 +93,7 @@ export async function simulateQuotes(
  * @param args.client - Client used to issue the simulation.
  * @param args.swap - Swap parameters attached to the quote.
  * @param args.quote - Quote instance to simulate.
+ * @param args.simulationOptions - Optional simulation controls, including state overrides.
  * @returns Quote data merged with its simulation result.
  */
 export async function simulateQuote(args: SimulationArgs): Promise<SimulatedQuote> {
@@ -112,6 +115,7 @@ async function performSimulation({
   client,
   swap,
   quote,
+  simulationOptions,
 }: SimulationArgs): Promise<SimulationResult> {
   if (!quote.success) {
     return {
@@ -152,12 +156,10 @@ async function performSimulation({
     const { results, block } = await simulateCalls(client, {
       account: swap.swapperAccount,
       calls,
-      stateOverrides: [
-        {
-          address: swap.swapperAccount,
-          balance: parseEther("10000"), // large amount to cover gas costs + swap value
-        },
-      ],
+      stateOverrides: simulationStateOverrides(
+        swap.swapperAccount,
+        simulationOptions?.stateOverrides,
+      ),
     });
     const latency = performance.now() - time;
 
@@ -202,6 +204,7 @@ async function performCrossChainSimulation({
   client,
   swap,
   quote,
+  simulationOptions,
 }: SimulationArgs): Promise<SimulationResult> {
   if (!quote.success) {
     return {
@@ -230,12 +233,10 @@ async function performCrossChainSimulation({
     const { results, block } = await simulateCalls(client, {
       account: swap.swapperAccount,
       calls,
-      stateOverrides: [
-        {
-          address: swap.swapperAccount,
-          balance: parseEther("10000"), // large amount to cover gas costs + swap value
-        },
-      ],
+      stateOverrides: simulationStateOverrides(
+        swap.swapperAccount,
+        simulationOptions?.stateOverrides,
+      ),
     });
     const latency = performance.now() - time;
     const swapResult = results[results.length - 1];
@@ -262,6 +263,88 @@ async function performCrossChainSimulation({
 }
 
 /// Utils ///
+
+function simulationStateOverrides(
+  swapperAccount: Address,
+  stateOverrides?: StateOverride,
+): StateOverride {
+  return mergeSimulationStateOverrides(
+    [
+      {
+        address: swapperAccount,
+        balance: parseEther("10000"), // large amount to cover gas costs + swap value
+      },
+    ],
+    stateOverrides,
+  );
+}
+
+export function mergeSimulationStateOverrides(
+  base: StateOverride,
+  extra?: StateOverride,
+): StateOverride {
+  if (!extra || extra.length === 0) {
+    return base;
+  }
+
+  const merged = new Map<string, StateOverride[number]>();
+  for (const item of [...base, ...extra]) {
+    const key = item.address.toLowerCase();
+    const existing = merged.get(key);
+    merged.set(key, existing ? mergeAccountOverride(existing, item) : item);
+  }
+  return [...merged.values()];
+}
+
+function mergeAccountOverride(
+  existing: StateOverride[number],
+  incoming: StateOverride[number],
+): StateOverride[number] {
+  const merged = {
+    ...existing,
+    ...incoming,
+  } as StateOverride[number] & {
+    state?: StateOverride[number]["state"];
+    stateDiff?: StateOverride[number]["stateDiff"];
+  };
+
+  if ("state" in incoming && incoming.state !== undefined) {
+    merged.state = incoming.state;
+    delete merged.stateDiff;
+    return merged;
+  }
+
+  if ("stateDiff" in incoming && incoming.stateDiff !== undefined) {
+    const current = "stateDiff" in existing ? existing.stateDiff : undefined;
+    merged.stateDiff = mergeStateMappings(current, incoming.stateDiff);
+    delete merged.state;
+    return merged;
+  }
+
+  if ("state" in existing && existing.state !== undefined) {
+    merged.state = existing.state;
+    delete merged.stateDiff;
+  } else if ("stateDiff" in existing && existing.stateDiff !== undefined) {
+    merged.stateDiff = existing.stateDiff;
+    delete merged.state;
+  }
+
+  return merged;
+}
+
+function mergeStateMappings(
+  current?: StateOverride[number]["stateDiff"],
+  incoming?: StateOverride[number]["stateDiff"],
+): NonNullable<StateOverride[number]["stateDiff"]> {
+  const merged = new Map<string, NonNullable<StateOverride[number]["stateDiff"]>[number]>();
+  for (const mapping of current ?? []) {
+    merged.set(mapping.slot.toLowerCase(), mapping);
+  }
+  for (const mapping of incoming ?? []) {
+    merged.set(mapping.slot.toLowerCase(), mapping);
+  }
+  return [...merged.values()];
+}
 
 function buildBalanceCall({
   client,

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Address, PublicClient, SimulateCallsReturnType } from "viem";
+import type { Address, PublicClient, SimulateCallsReturnType, StateOverride } from "viem";
 import type { ZeroXConfig, ZeroXQuoteResponse } from "./aggregators/0x.js";
 import type { FabricConfig, FabricQuoteResponse } from "./aggregators/fabric.js";
 import type { Aggregator } from "./aggregators/index.js";
@@ -650,6 +650,19 @@ export type ConfigParams = DirectConfigParams | ProxyConfigParams;
 ///////////////////// Simulation Types /////////////////////
 
 /**
+ * Optional controls for quote simulation behavior.
+ *
+ * @public
+ */
+export type SimulationOptions = {
+  /**
+   * Account and storage overrides forwarded to `simulateCalls`.
+   * Caller-provided values take precedence over spanDEX simulation defaults.
+   */
+  stateOverrides?: StateOverride;
+};
+
+/**
  * Parameters required to simulate a single quote.
  *
  * @public
@@ -661,6 +674,8 @@ export type SimulationArgs = {
   swap: SwapParams;
   /** Quote to simulate, including the encoded transaction data. */
   quote: Quote;
+  /** Optional simulation controls, including caller-provided state overrides. */
+  simulationOptions?: SimulationOptions;
 };
 
 /**

--- a/packages/core/lib/wire/proxy.test.ts
+++ b/packages/core/lib/wire/proxy.test.ts
@@ -6,8 +6,9 @@ import { createConfig } from "../createConfig.js";
 import { getQuote } from "../getQuote.js";
 import { getQuotes } from "../getQuotes.js";
 import { getRawQuotes } from "../getRawQuotes.js";
-import type { Quote, SimulatedQuote, SwapParams } from "../types.js";
+import type { Quote, SimulatedQuote, SimulationOptions, SwapParams } from "../types.js";
 import { proxy } from "./proxy.js";
+import { deserializeWithBigInt } from "./serde.js";
 import { newStream, quoteStreamErrorHandler, simulatedQuoteStreamErrorHandler } from "./streams.js";
 
 function makeSimulatedQuote(outputAmount: bigint): SimulatedQuote {
@@ -205,7 +206,36 @@ describe("proxy", () => {
 
     expect(quotes).toHaveLength(1);
     expect(quotes[0]?.simulation).toBeDefined();
-    expect(new URL(requests[0]?.url || "").pathname).toBe("/api/prepareSimulatedQuotes");
+    const url = new URL(requests[0]?.url || "");
+    expect(url.pathname).toBe("/api/prepareSimulatedQuotes");
+    expect(url.searchParams.get("simulationOptions")).toBeNull();
+  }, 10_000);
+
+  it("forwards bigint-aware simulationOptions to delegated simulation", async () => {
+    enqueueSimulated();
+    const simulationOptions: SimulationOptions = {
+      stateOverrides: [
+        {
+          address: defaultSwapParams.inputToken,
+          balance: 123n,
+          stateDiff: [{ slot: "0x01", value: "0x02" }],
+        },
+      ],
+    };
+
+    await getQuotes({
+      config: createConfig({
+        proxy: proxy({ pathOrUrl: baseUrl, delegatedActions }),
+      }),
+      swap: defaultSwapParams,
+      simulationOptions,
+    });
+
+    const request = requests[0];
+    expect(request).toBeDefined();
+    const encoded = new URL(request?.url || "").searchParams.get("simulationOptions");
+    expect(encoded).not.toBeNull();
+    expect(deserializeWithBigInt<SimulationOptions>(encoded as string)).toEqual(simulationOptions);
   }, 10_000);
 
   it("selects quotes locally from streamed simulated proxy results", async () => {

--- a/packages/core/lib/wire/proxy.ts
+++ b/packages/core/lib/wire/proxy.ts
@@ -1,4 +1,5 @@
-import type { Quote, SimulatedQuote, SwapParams } from "../types.js";
+import type { Quote, SimulatedQuote, SimulationOptions, SwapParams } from "../types.js";
+import { serializeWithBigInt } from "./serde.js";
 import { decodeStream } from "./streams.js";
 
 export type ProxyDelegatedAction = "prepareQuotes" | "prepareSimulatedQuotes";
@@ -58,11 +59,18 @@ export class AggregatorProxy {
   /**
    * Request simulated quotes from the configured proxy endpoint.
    * @param params - Swap parameters to retrieve quotes for
+   * @param simulationOptions - Optional controls forwarded to server-side simulation.
    * @returns Promises that resolve to individual simulated quote results as they stream in.
    */
-  async prepareSimulatedQuotes(params: SwapParams): Promise<Array<Promise<SimulatedQuote>>> {
+  async prepareSimulatedQuotes(
+    params: SwapParams,
+    simulationOptions?: SimulationOptions,
+  ): Promise<Array<Promise<SimulatedQuote>>> {
     this.assertDelegatedAction("prepareSimulatedQuotes");
     const query = quoteQueryParams(params);
+    if (simulationOptions !== undefined) {
+      query.append("simulationOptions", serializeWithBigInt(simulationOptions));
+    }
     return this.fetchStream<SimulatedQuote>(
       `${this.baseUrl}/prepareSimulatedQuotes?${query.toString()}`,
       decodeStream,

--- a/site/docs/pages/configuration/proxy.mdx
+++ b/site/docs/pages/configuration/proxy.mdx
@@ -44,7 +44,8 @@ simulation infrastructure to the server.
 ## How It Works
 
 1. Client calls quote APIs/hooks (`getQuotes`, `getQuote`, `getRawQuotes`, `useQuotes`, etc).
-2. `AggregatorProxy` serializes swap params into query params and calls your endpoint.
+2. `AggregatorProxy` serializes swap params into query params and calls your endpoint. Optional
+   simulation controls are encoded with bigint support in the `simulationOptions` query parameter.
 3. `prepareQuotes` uses a streaming response (`newStream(...)`) so quotes arrive progressively.
 4. `prepareSimulatedQuotes` uses a streaming response (`newStream(...)`) so simulated
    quotes arrive progressively.
@@ -66,20 +67,21 @@ import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { zValidator } from "@hono/zod-validator";
 import {
+  deserializeWithBigInt,
   newStream,
   prepareQuotes,
   prepareSimulatedQuotes,
   quoteStreamErrorHandler,
   simulatedQuoteStreamErrorHandler,
   type Quote,
+  type SimulationOptions,
   type SimulatedQuote,
-  type SwapParams,
 } from "@spandex/core";
 
 const app = new Hono();
 
 app.get("/prepareQuotes", zValidator("query", querySchema), async (c) => {
-  const swap = c.req.valid("query") satisfies SwapParams;
+  const { simulationOptions: _, ...swap } = c.req.valid("query");
   return stream(c, async (streamWriter) => {
     const prepared = await prepareQuotes<Quote>({
       swap,
@@ -91,11 +93,15 @@ app.get("/prepareQuotes", zValidator("query", querySchema), async (c) => {
 });
 
 app.get("/prepareSimulatedQuotes", zValidator("query", querySchema), async (c) => {
-  const swap = c.req.valid("query") satisfies SwapParams;
+  const { simulationOptions: encodedSimulationOptions, ...swap } = c.req.valid("query");
+  const simulationOptions = encodedSimulationOptions
+    ? deserializeWithBigInt<SimulationOptions>(encodedSimulationOptions)
+    : undefined;
   return stream(c, async (streamWriter) => {
     const prepared = await prepareSimulatedQuotes({
       swap,
       config,
+      simulationOptions,
     });
     await streamWriter.pipe(
       newStream<SimulatedQuote>(prepared, simulatedQuoteStreamErrorHandler),
@@ -103,6 +109,10 @@ app.get("/prepareSimulatedQuotes", zValidator("query", querySchema), async (c) =
   });
 });
 ```
+
+The endpoint's query schema must accept `simulationOptions` as an optional string. Deserialize it
+with `deserializeWithBigInt` before passing it to `prepareSimulatedQuotes`; ordinary JSON parsing
+does not preserve bigint balances.
 
 ## React Streaming and Async Iterators
 

--- a/site/docs/pages/core/functions/getQuote.mdx
+++ b/site/docs/pages/core/functions/getQuote.mdx
@@ -89,10 +89,12 @@ type QuoteSelectionFn = (
 
 Optional custom PublicClient to use for onchain simulations. If not provided, the configured clients in the `config` will be used.
 
-### simulate
-`typeof simulateQuote | undefined`
+### simulationOptions
+`SimulationOptions | undefined`
 
-Optional override for the simulation function used on each quote.
+Optional simulation controls. Use `stateOverrides` to provide viem account or storage overrides for
+indicative quotes where the swapper does not have the required onchain balance. Caller-provided
+values take precedence over spanDEX's built-in native-balance override.
 
 ## Returns
 

--- a/site/docs/pages/core/functions/getQuotes.mdx
+++ b/site/docs/pages/core/functions/getQuotes.mdx
@@ -71,6 +71,12 @@ Parameters defining the swap operation. See [SwapParams reference](/reference/Sw
 
 Optional custom PublicClient to use for onchain simulations. If not provided, the configured clients in the `config` will be used.
 
+### simulationOptions
+
+`SimulationOptions | undefined`
+
+Optional simulation controls. Its `stateOverrides` field accepts viem account and storage
+overrides, including ERC-20 balance storage slots for indicative quotes.
 
 ## Returns
 

--- a/site/docs/pages/core/functions/simulateQuote.mdx
+++ b/site/docs/pages/core/functions/simulateQuote.mdx
@@ -32,6 +32,14 @@ const simulated = await simulateQuote({
   quote: first,
   swap,
   client,
+  simulationOptions: {
+    stateOverrides: [
+      {
+        address: swap.inputToken,
+        stateDiff: [{ slot: balanceSlot, value: simulatedBalance }],
+      },
+    ],
+  },
 });
 
 if (simulated.success && simulated.simulation.success) {
@@ -55,6 +63,12 @@ Swap parameters associated with the quote. See [SwapParams reference](/reference
 `Quote`
 
 Quote to simulate.
+
+### simulationOptions
+`SimulationOptions | undefined`
+
+Optional simulation controls forwarded to viem's `simulateCalls`. Overrides are merged by account
+address with spanDEX's built-in native-balance override, with caller values winning conflicts.
 
 ## Returns
 

--- a/site/docs/pages/core/functions/simulateQuotes.mdx
+++ b/site/docs/pages/core/functions/simulateQuotes.mdx
@@ -50,6 +50,12 @@ Swap parameters shared across all quotes. See [SwapParams reference](/reference/
 
 Quotes to simulate.
 
+### simulationOptions
+`SimulationOptions | undefined`
+
+Optional simulation controls shared across every quote. The `stateOverrides` field accepts viem
+account and storage overrides.
+
 ## Returns
 
 `Promise<SimulatedQuote[]>`

--- a/site/docs/pages/simulation.mdx
+++ b/site/docs/pages/simulation.mdx
@@ -30,3 +30,32 @@ To enable onchain simulation, you'll need:
 1. a viem `PublicClient` connected to the target chain
 2. a `MetaAggregator` instance from the core spanDEX package with your desired aggregators configured
 
+## Indicative Quotes with State Overrides
+
+For an indicative quote, the swapper account may not hold the input token. Pass viem state
+overrides through `simulationOptions` after resolving the token's balance storage slot:
+
+```ts
+const quote = await getQuote({
+  config,
+  swap,
+  strategy: "bestPrice",
+  simulationOptions: {
+    stateOverrides: [
+      {
+        address: swap.inputToken,
+        stateDiff: [
+          {
+            slot: balanceSlot,
+            value: simulatedBalance,
+          },
+        ],
+      },
+    ],
+  },
+});
+```
+
+spanDEX retains its default native balance for simulation gas unless the caller explicitly
+overrides that balance. State changes are used only for simulation and are not included in
+transaction execution.


### PR DESCRIPTION
## Changes

allow integrators to override state, such as token balance, while simulating

## Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/withfabricxyz/spandex/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `bun test`.

## Release Impact

- [x] This change impacts released packages, and I have created a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change does not impact released packages (tests,docs,examples) (no release).